### PR TITLE
add initial support for xcompose conversion to yamlcompose

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,33 @@ Options:
 
 _note: Some programs need a hard reboot to take in the map, like `kill -9` sort of reboot to start working._
 
+## Using XCompose Mappings
+
+Linux's xcompose mappings are supported via experimental conversion:
+
+```
+$ gen-compose-conver xcompose --help
+Usage: gen-compose-convert xcompose [OPTIONS] [FILES]...
+
+  Convert xcompose file, that follows format like: <Multi_key> <parenleft>
+  <period> <1> <parenright>: "⑴"
+
+Options:
+  -c, --keep-comments  keep inline comments
+  --help               Show this message and exit.
+```
+
+For example:
+
+```
+$ cat mappings/example.compose
+<Multi_key> <B> <bar> : "₿" U20BF  # BITCOIN SIGN
+$ gen-compose-convert xcompose mappings/example.compose --keep-comments > example.yaml
+$ cat example.yaml
+"B|": "₿"  # BITCOIN SIGN
+```
+
+
 ## Notes and Issues
 
 * There's no way to really debug this other than trial and error and making sure applications are restarted after every update.  

--- a/convcompose.py
+++ b/convcompose.py
@@ -103,7 +103,7 @@ def xcompose(files, keep_comments):
             except ValueError:
                 echo(f'malformed line:\n{row}', err=True)
                 continue
-            from_ = re.split('\s+', from_)
+            from_ = re.split(r'\s+', from_)
             try:
                 from_ = ''.join(remap_keys(from_))
             except ValueError as e:

--- a/convcompose.py
+++ b/convcompose.py
@@ -1,0 +1,120 @@
+import click
+import re
+
+from click import echo
+
+KEY_MAP = {
+    'bracketleft': '[',
+    'bracketright': ']',
+    'parenleft': '(',
+    'parenright': ')',
+    'Multi_key': '',
+    'period': '.',
+    'minus': '-',
+    'plus': '+',
+    'dollar': '$',
+    'at': '@',
+    'exclam': '!',
+    'less': '<',
+    'greater': '>',
+    'slash': '/',
+    'backslash': '\\',
+    'question': '?',
+    'space': ' ',
+    'equal': '=',
+    'asciitilde': '~',
+    'numbersign': '#',
+    'asterisk': '*',
+    'colon': ':',
+    'semicolon': ';',
+    'percent': '%',
+    'underscore': '_',
+    'asciicircum': '^',
+    'comma': ',',
+    'apostrophe': "'",
+    'quotedbl': '"',
+    'bar': "|",
+    'grave': "`",
+    'ampersand': "&",
+    'braceright': "}",
+    'braceleft': "{",
+    'KP_Multiply': "*",
+    'exclamdown': "¡",
+    'questiondown': "¿",
+}
+
+
+def quote(char):
+    """
+    quote yaml key
+    - replaces `\` to `\\`
+    - replace `"` to `\"`
+    """
+    char = char.replace('\\', '\\\\')
+    char = char.replace('"', '\\"')
+    return char
+
+
+def remap_keys(keys):
+    """remap xcompose keys to unicode characters"""
+    result = []
+    for key in keys:
+        key = key.strip('<>')
+        if len(key) > 1:
+            # convert unicode hexes to unicode characters
+            # e.g. U220B == ∋
+            if key.startswith('U') and any(c.isdigit() for c in key):
+                key = key.split('U', 1)[1]
+                key = chr(int(key, 16))
+            elif key not in KEY_MAP:
+                raise ValueError(f'unsupported keymap: {key}')
+        result.append(KEY_MAP.get(key, key))
+    return result
+
+
+@click.group()
+def main():
+    """convert alternative formats to yaml key: value format"""
+    pass
+
+
+@main.command()
+@click.argument('files', type=click.File(), nargs=-1)
+@click.option('-c', '--keep-comments', is_flag=True, help='keep inline comments')
+def xcompose(files, keep_comments):
+    """
+    Convert xcompose file, that follows format like:
+    <Multi_key> <parenleft> <period> <1> <parenright>: "⑴"
+    """
+    # e.g. < Multi_key > < parenleft > < period > < 1 > < parenright >: "⑴"
+    for file in files:
+        for row in file:
+            row = row.strip()
+            if not row:
+                continue
+            if row.startswith('#') or row.startswith('include'):
+                continue
+            if '#' in row:
+                row, comment = row.split('#', 1)
+            else:
+                comment = ''
+            try:
+                from_, to = row.split(':', 1)
+            except ValueError:
+                echo(f'malformed line:\n{row}', err=True)
+                continue
+            from_ = re.split('\s+', from_)
+            try:
+                from_ = ''.join(remap_keys(from_))
+            except ValueError as e:
+                echo(f'{e}; skipping:\n  {row}', err=True)
+                continue
+            to = to.split('"')[1]
+            value = f'"{quote(from_)}": "{quote(to)}"'
+            if keep_comments and comment:
+                value += f'  #{comment}'
+            echo(value)
+
+
+if __name__ == '__main__':
+    main()

--- a/mappings/xcompose.compose
+++ b/mappings/xcompose.compose
@@ -1,0 +1,1419 @@
+# for Emacs: -*- coding: utf-8 -*-
+include "%L"
+
+# def emit(keys, codepoint, word):
+#     print ('<Multi_key> %s <period>\t: "%s"\tU%04X\t\t# CIRCLED DIGIT %s' % 
+#            (keys, unichr(codepoint), codepoint, word)).encode('utf8')
+# numbers = 'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty'
+# words = numbers.upper().split()
+# emit('<0>', 0x24EA, "ZERO")
+# for num, word in zip(range(1, 21), words):
+#     emit(' '.join("<%s>" % char for char in str(num)), 0x245f + num, word)
+
+# Custom additions: Typography
+<Multi_key> <period> <period>		: "…"	U2026		# HORIZONTAL ELLIPSIS
+<Multi_key> <v> <period> <period>	: "⋮"	U22EE		# VERTICAL ELLIPSIS
+<Multi_key> <c> <period> <period>	: "⋯"	U22EF		# MIDLINE HORIZONTAL ELLIPSIS
+<Multi_key> <slash> <period> <period>	: "⋰"	U22F0		# UP RIGHT DIAGONAL ELLIPSIS
+# To avoid conflict with \. for combining dot above.
+#<Multi_key> <backslash> <period> <period> : "⋱" U22F1		# DOWN RIGHT DIAGONAL ELLIPSIS
+<Multi_key> <period> <backslash> <period> : "⋱" U22F1		# DOWN RIGHT DIAGONAL ELLIPSIS
+# Will we someday regret this, wanting 2. for ⒉ ?
+<Multi_key> <2> <period>	 	  : "‥"	U2025		# TWO DOT LEADER
+# This should not be needed.
+#<Multi_key> <1> <period>		  : "․"	U2024		# ONE DOT LEADER
+<Multi_key> <c> <1> <period>		  : "·"	U00B7		# MIDDLE DOT (maybe I can remember the keystroke better?
+<Multi_key> <period> <slash> <period>	: "⁒"	U2052		# COMMERCIAL MINUS SIGN
+### or && ?
+<Multi_key> <ampersand> <at>    :   "⅋" U214B   # TURNED AMPERSAND
+<Multi_key> <ampersand> <7>     :   "⁊" U204A   # TIRONIAN SIGN ET
+# Printable sign for space.  But is \<space> too useful a key combo to use
+# for this?
+<Multi_key> <backslash> <space>		: "␣"	U2423		# OPEN BOX
+# These two are already present for me:
+# <Multi_key> <minus> <minus> <minus>	: "—"	U2014		# EM DASH
+# <Multi_key> <minus> <minus> <period>	: "–"	U2013		# EN DASH
+<Multi_key> <minus> <minus> <space>	: "– "			# EN DASH (followed by space)
+<Multi_key> <minus> <asciitilde> <minus> : "―" U2015 # HORIZONTAL BAR
+<Multi_key> <minus> <2> <M>	 	 : "⸺" U2E3A # TWO-EM DASH
+<Multi_key> <minus> <3> <M>	 	 : "⸻" U2E3B # THREE-EM DASH
+<Multi_key> <backslash> <minus>		: "­"	U00AD		# SOFT HYPHEN
+# This is the recommended typographical practice for em dashes in English.
+# Unfortunately, it doesn’t work out all that well in monospace fonts,
+# where the thin spaces aren’t thin.  But I think this is okay.
+# This conflicts with the default binding to “~”, which is potentially
+# a problem for non-American keyboards.
+<Multi_key> <space> <minus>             : " — "                 # EM DASH surrounded by THIN SPACEs.
+
+
+# Quotation marks.
+<Multi_key> <comma> <space>		: "‚"	U201A		# SINGLE LOW-9 QUOTATION MARK
+<Multi_key> <comma> <comma>		: "„"	U201E		# DOUBLE LOW-9 QUOTATION MARK
+<Multi_key> <less> <comma> <comma>	: "⹂"	U2E42		# DOUBLE LOW-REVERSED-9 QUOTATION MARK
+<Multi_key> <apostrophe> <space>	: "’"	U2019		# RIGHT SINGLE QUOTATION MARK
+<Multi_key> <apostrophe> <apostrophe>	: "”"	U201D		# RIGHT DOUBLE QUOTATION MARK
+<Multi_key> <grave> <space>		: "‘"	U2018		# LEFT SINGLE QUOTATION MARK
+<Multi_key> <grave> <grave>		: "“"	U201C		# LEFT DOUBLE QUOTATION MARK
+<Multi_key> <6> <apostrophe>		: "‘"	U2018		# LEFT SINGLE QUOTATION MARK (high 6)
+<Multi_key> <6> <quotedbl>		: "“"	U201C		# LEFT DOUBLE QUOTATION MARK (66)
+<Multi_key> <9> <apostrophe>		: "’"	U2019		# RIGHT SINGLE QUOTATION MARK (high 9)
+<Multi_key> <9> <quotedbl>		: "”"	U201D		# RIGHT DOUBLE QUOTATION MARK (99)
+<Multi_key> <less> <9> <apostrophe>	: "‛"	U201B		# SINGLE HIGH-REVERSED-9 QUOTATION MARK
+<Multi_key> <less> <9> <quotedbl>	: "‟"	U201F		# DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+<Multi_key> <comma> <apostrophe>	: "‚"	U201A		# SINGLE LOW-9 QUOTATION MARK (quote resembling a comma)
+<Multi_key> <comma> <quotedbl>		: "„"	U201E		# DOUBLE LOW-9 QUOTATION MARK
+
+# Convenience shortcuts for quotation marks.
+<Multi_key> <space> <quotedbl>          : " “"                  # space followed by LEFT DOUBLE QUOTATION MARK
+<Multi_key> <quotedbl> <space>          : "” "                  # RIGHT DOUBLE QUOTATION MARK followed by space
+<Multi_key> <space> <apostrophe>        : " ‘"                # space followed by LEFT SINGLE QUOTATION MARK
+# Unfortunately <apostrophe> <space> is, asymmetrically, just "’".  Whatever.
+<Multi_key> <n> <t>                     : "n’t "              # Apostrophized English “not.”
+# Some more English shortcuts:
+<Multi_key> <space> <t>                 : " the "
+<Multi_key> <space> <T>                 : "  The "
+<Multi_key> <space> <a>                 : " and "
+<Multi_key> <i> <m>                     : " I’m "
+<Multi_key> <v> <e>                     : "’ve "
+
+<Multi_key> <comma> <at>		: "⸲"	U2E32		# TURNED COMMA
+# Conflicts with system def? (·)
+<Multi_key> <period> <asciicircum>	: "⸳"	U2E33		# RAISED DOT
+<Multi_key> <period> <asciitilde>	: "⸳"	U2E33		# RAISED DOT
+<Multi_key> <comma> <asciicircum>	: "⸴"	U2E34		# RAISED COMMA
+<Multi_key> <semicolon> <at>		: "⸵"	U2E35		# TURNED SEMICOLON
+# Convlicts with system def? (⍭)
+<Multi_key> <asciitilde> <bar>		: "ⸯ"	U2E2F		# VERTICAL TILDE
+<Multi_key> <asciicircum> <bar>		: "ⸯ"	U2E2F		# VERTICAL TILDE
+<Multi_key> <minus> <equal>		: "⹀"	U2E40		# DOUBLE HYPHEN
+<Multi_key> <comma> <less>		: "⹁"	U2E41		# REVERSED COMMA
+<Multi_key> <less> <bar>		: "↵"	U21B5		# DOWNWARDS ARROW WITH CORNER LEFTWARDS
+# The bullet was <o> <period>, but it clashes with ꙭ
+<Multi_key> <asterisk> <1>		: "•"	U2022		# BULLET
+# By default <Multi_key> <period> <period> does this, but we broke that with the ... binding.
+<Multi_key> <o> <underscore>		: "⁃"   U2043		# HYPHEN BULLET
+<Multi_key> <o> <comma>			: "·"	periodcentered	# MIDDLE DOT
+# I don’t use this nearly as often as the em-dash sequence I’ve remapped it to:
+#<Multi_key> <space> <minus>		: "‑"	U2011		# NON-BREAKING HYPHEN
+# Already present for me:
+# <Multi_key> <space> <space>		: " "	U00A0		# NO-BREAK SPACE
+# Narrow no-break space, needed for some Latin languages like French
+<Multi_key> <space> <n>                 : " "   U202f # NARROW NO-BREAK SPACE
+# Technically, NO-BREAK SPACE is not supposed to be fixed-width.  This is:
+<Multi_key> <space> <numbersign> :   " "      U2007             # FIGURE SPACE
+# We used to have THIN SPACE as <space> <apostrophe>, but now that’s remapped
+# to " ‘", for conveniently enclosing things in proper single-quotes.
+<Multi_key> <backslash> <comma>		: " "	U2009		# THIN SPACE
+# (heh, heh... space bar)
+<Multi_key> <space> <bar>               : " "   U200A           # HAIR SPACE
+<Multi_key> <d> <a> <g>			: "†"	U2020		# DAGGER
+<Multi_key> <d> <d> <a> <g>		: "‡"	U2021		# DOUBLE DAGGER
+<Multi_key> <s> <e> <c> : "§"   U00A7   # SECTION SIGN
+# It's in the Asian section, but it's a general-purpose punctuation:
+<Multi_key> <quotedbl> <quotedbl>       : "〃"	U3003		# DITTO MARK
+# Working with the pattern from FLOOR/CEILING
+<Multi_key> <7> <asciicircum> <bracketleft>  : "⸢"  U2E22	# TOP LEFT HALF BRACKET
+<Multi_key> <7> <asciicircum> <bracketright> : "⸣"  U2E23	# TOP RIGHT HALF BRACKET
+<Multi_key> <L> <underscore> <bracketleft>   : "⸤"  U2E24	# BOTTOM LEFT HALF BRACKET
+<Multi_key> <L> <underscore> <bracketright>  : "⸥"  U2E25	# BOTTOM RIGHT HALF BRACKET
+# Consider <7> <less>/<greater> for ⸂⸃ maybe? <S> and <slash> for ⸉⸊⸌⸍ ...?
+# I guess we can get by with sub/superset for ⸦⸧.
+
+<Multi_key> <minus> <less>		: "←"	leftarrow	# LEFTWARDS ARROW
+<Multi_key> <minus> <asciicircum>	: "↑"	uparrow		# UPWARDS ARROW
+<Multi_key> <minus> <greater>		: "→"	rightarrow	# RIGHTWARDS ARROW
+<Multi_key> <minus> <v>			: "↓"	downarrow	# DOWNWARDS ARROW
+<Multi_key> <less> <minus> <greater>	: "↔"	U2194           # LEFT RIGHT ARROW (kragen's)
+
+<Multi_key> <Left> <Left>		: "←"	leftarrow	# LEFTWARDS ARROW
+<Multi_key> <Up> <Up>			: "↑"	uparrow		# UPWARDS ARROW
+<Multi_key> <Right> <Right>		: "→"	rightarrow	# RIGHTWARDS ARROW
+<Multi_key> <Down> <Down>		: "↓"	downarrow	# DOWNWARDS ARROW
+<Multi_key> <Left> <Right>		: "↔"	U2194           # LEFT RIGHT ARROW (kragen's)
+<Multi_key> <Right> <Left>		: "↔"	U2194           # LEFT RIGHT ARROW (kragen's)
+<Multi_key> <Up> <Down>			: "↕"	U2195           # UP DOWN ARROW (kragen's)
+<Multi_key> <Up> <ampersand> <Down>     : "⇵"	U21F5		# DOWNWARDS ARROW LEFTWARDS OF UPWARDS ARROW
+<Multi_key> <Down> <Left>		: "↵"	U21B5		# DOWNWARDS ARROW WITH CORNER LEFTWARDS
+<Multi_key> <Left> <o>			: "⟲"	U27F2		# ANTICLOCKWISE GAPPED CIRCLE ARROW
+<Multi_key> <Right> <o>			: "⟳"	U27F3		# CLOCKWISE GAPPED CIRCLE ARROW
+<Multi_key> <Left> <c>			: "↺"	U21BA		# ANTICLOCKWISE OPEN CIRCLE ARROW
+<Multi_key> <Right> <c>			: "↻"	U21BB		# CLOCKWISE OPEN CIRCLE ARROW
+<Multi_key> <Left> <asciitilde>		: "⇜"	U21DC		# LEFTWARDS SQUIGGLE ARROW
+<Multi_key> <asciitilde> <Left> <asciitilde>    : "⬳"  U2B33    # LONG LEFTWARDS SQUIGGLE ARROW
+<Multi_key> <Right> <asciitilde>	: "⇝"	U21DD		# RIGHTWARDS SQUIGGLE ARROW
+<Multi_key> <asciitilde> <Right> <asciitilde>   : "⟿"  U27FF    # LONG RIGHTWARDS SQUIGGLE ARROW
+<Multi_key> <Left> <bar>       		: "⇤"	U21E4		# LEFTWARDS ARROW TO BAR
+<Multi_key> <Right> <bar>       	: "⇥"	U21E5		# RIGHTWARDS ARROW TO BAR
+<Multi_key> <Left> <minus>     		: "⇠"	U21E0		# LEFTWARDS DASHED ARROW
+<Multi_key> <Up> <minus>     		: "⇡"	U21E1		# UPWARDS DASHED ARROW
+<Multi_key> <Right> <minus>     	: "⇢"	U21E2		# RIGHTWARDS DASHED ARROW
+<Multi_key> <Down> <minus>      	: "⇣"	U21E3		# DOWNWARDS DASHED ARROW
+<Multi_key> <z> <z> <greater>           : "↯"   U21AF           # DOWNWARDS ZIGZAG ARROW
+
+# Arrow keys don't always work: some apps trap them for cursor control and
+# other boring things.  The arrow symbols have alternate keystrokes.  Do
+# we need others for these printer's fists?  If so, what?  The -= and =-
+# we had before are not necessarily the best choices.
+<Multi_key> <F> <Left>		: "☚"	U261A		# BLACK LEFT POINTING INDEX
+<Multi_key> <F> <Right>		: "☛"	U261B		# BLACK RIGHT POINTING INDEX
+<Multi_key> <f> <Left>		: "☜"	U261C		# WHITE LEFT POINTING INDEX
+<Multi_key> <f> <Up>		: "☝"	U261D		# WHITE UP POINTING INDEX
+<Multi_key> <f> <Right>		: "☞"	U261E		# WHITE RIGHT POINTING INDEX
+<Multi_key> <f> <Down>		: "☟"	U261F		# WHITE DOWN POINTING INDEX
+<Multi_key> <f> <v>   		: "✌"   U270C   	# VICTORY HAND
+<Multi_key> <f> <w>   		: "✍"   U270D   	# WRITING HAND
+<Multi_key> <f> <p> <Down>	: "✎"   U270E   	# LOWER RIGHT PENCIL
+<Multi_key> <f> <p> <Right>	: "✏"   U270F   	# PENCIL
+<Multi_key> <f> <p> <Up>	: "✐"   U2710   	# UPPER RIGHT PENCIL
+
+# For some logical statements.  I prefer doubled arrows for implication.
+<Multi_key> <equal> <greater>		: "⇒"	U21D2		# RIGHTWARDS DOUBLE ARROW
+<Multi_key> <equal> <less>		: "⇐"	U21D0		# LEFTWARDS DOUBLE ARROW
+<Multi_key> <less> <minus> <equal> <greater> : "⇔" U21D4 # LEFT RIGHT DOUBLE ARROW 
+<Multi_key> <equal> <Right> <Right>	: "⇒"	U21D2		# RIGHTWARDS DOUBLE ARROW
+<Multi_key> <equal> <Left> <Left>	: "⇐"	U21D0		# LEFTWARDS DOUBLE ARROW
+<Multi_key> <equal> <Left> <Right>	: "⇔"	U21D4	# LEFT RIGHT DOUBLE ARROW
+<Multi_key> <equal> <Right> <Left>	: "⇔"	U21D4	# LEFT RIGHT DOUBLE ARROW
+<Multi_key> <equal> <Up> <Up>		: "⇑"	U21D1	# UPWARDS DOUBLE ARROW
+<Multi_key> <equal> <Down> <Down>	: "⇓"	U21D3	# DOWNWARDS DOUBLE ARROW
+<Multi_key> <equal> <Up> <Down>		: "⇕"	U21D5	# UP DOWN DOUBLE ARROW
+<Multi_key> <equal> <Down> <Left>	: "⏎"	U23CE	# RETURN SYMBOL
+# These are just too cool-looking not to have (if your font supports them)
+<Multi_key> <equal> <period> <equal>	: "⸎"	U2E0E		# EDITORIAL CORONIS
+<Multi_key> <Multi_key> <p> <a> <l> <m>	: "⸙"	U2E19		# PALM BRANCH
+<Multi_key> <Multi_key> <b> <r> <a> <n> <c> <h>: "⸙"	U2E19		# PALM BRANCH
+
+
+<Multi_key> <f> <f>		: "ﬀ"	   UFB00   # LATIN SMALL LIGATURE FF
+<Multi_key> <f> <i>		: "ﬁ"	   UFB01   # LATIN SMALL LIGATURE FI
+<Multi_key> <F> <i>		: "ﬃ"	   UFB03   # LATIN SMALL LIGATURE FFI
+<Multi_key> <f> <l>		: "ﬂ"	   UFB02   # LATIN SMALL LIGATURE FL
+<Multi_key> <F> <l>		: "ﬄ"	   UFB04   # LATIN SMALL LIGATURE FFL
+<Multi_key> <s> <t>		: "ﬆ"  UFB06	   # LATIN SMALL LIGATURE ST
+<Multi_key> <f> <t>		: "ﬅ"  UFB05	   # LATIN SMALL LIGATURE LONG S T
+# allow me still to use my ſ key, okay?
+<Multi_key> <U017F> <t>		: "ﬅ"  UFB05	   # LATIN SMALL LIGATURE LONG S T
+# ß is already available as <s><s> I think.  But now it comes in industrial size!
+<Multi_key> <S> <S> 		: "ẞ"  U1E9E	   # LATIN CAPITAL LETTER SHARP S
+
+# Eventually we'll have to look over the really crazy-cakes Latin letters 
+# they're adding as "mediævalist extensions"
+# ꜢꜣꜤꜥ for the Egyptologists, Ꝏꝏ because they're cꝏl...  Maybe some others.
+# Can't do <o> <o> for ꝏ though, since that's already °.
+# Epigraphics should not be missed:
+<Multi_key> <F> <less>		: "ꟻ"	UA7FB	# LATIN EPIGRAPHIC LETTER REVERSED F
+<Multi_key> <P> <less>		: "ꟼ"	UA7FC	# LATIN EPIGRAPHIC LETTER REVERSED P
+<Multi_key> <F> <BackSpace>		: "ꟻ"	UA7FB	# LATIN EPIGRAPHIC LETTER REVERSED F
+<Multi_key> <P> <BackSpace>		: "ꟼ"	UA7FC	# LATIN EPIGRAPHIC LETTER REVERSED P
+<Multi_key> <F> <F>                     : "Ⅎ"   U2132    # TURNED CAPITAL F
+<Multi_key> <F> <f>                     : "ⅎ"   U214E    # TURNED SMALL F
+<Multi_key> <M> <W>		: "ꟽ"	UA7FD	# LATIN EPIGRAPHIC LETTER INVERTED M
+<Multi_key> <M> <M>                 : "Ɯ"   U019C    # LATIN CAPITAL LETTER TURNED M
+<Multi_key> <I> <bar>		: "ꟾ"	UA7FE	# LATIN EPIGRAPHIC LETTER I LONGA
+<Multi_key> <M> <slash>		: "ꟿ"	UA7FF	# LATIN EPIGRAPHIC LETTER ARCHAIC M
+<Multi_key> <2> <2>                 : "↊"   U218A    # TURNED DIGIT TWO
+<Multi_key> <3> <3>                 : "↋"   U218B    # TURNED DIGIT THREE
+# I'd been avoiding this because we already have ∃...
+# Hey, these, being *letters* can be used as identifiers in some languages...
+<Multi_key> <E> <less>	 	 : "Ǝ"	    U018E	# LATIN CAPITAL LETTER REVERSED E
+<Multi_key> <E> <BackSpace>	 : "Ǝ"	    U018E	# LATIN CAPITAL LETTER REVERSED E
+<Multi_key> <e> <less>		 : "ɘ"	    U0258	# LATIN SMALL LETTER REVERSED E
+<Multi_key> <e> <BackSpace>	 : "ɘ"	    U0258	# LATIN SMALL LETTER REVERSED E
+# Complete the set
+<Multi_key> <A> <less>		 : "Ɐ"	    U2C6F	# LATIN CAPITAL LETTER TURNED A
+# These seem too long as keystrokes; any suggestions?
+# How about 2o?
+<Multi_key> <o> <ampersand> <o>	: "ꝏ"	UA74F	# LATIN SMALL LETTER OO
+<Multi_key> <O> <ampersand> <O> : "Ꝏ"	UA74E	# LATIN CAPITAL LETTER OO
+<Multi_key> <2> <o>	: "ꝏ"	UA74F	# LATIN SMALL LETTER OO
+<Multi_key> <2> <O> 	: "Ꝏ"	UA74E	# LATIN CAPITAL LETTER OO
+# Latin-D chars I'm particularly thinking about:
+# (side note: "I" has many referents in this file.)
+# ꜲꜳꜴꜵꜶꜷꜸꜹꜼꜽꝒꝓꝔꝕꝚꝛꝜꝝꝠꝡꝪꝫꝸ
+# The ligature pairs are so easy, might as well include them (probably
+# using ampersand though).  P with flourish?  Squirrel tail?  How
+# pretty!  I like the r and rum rotunda, and et actually has something
+# close to usefulness (it was very common for abbreviations, and is the 
+# source of the "z" in abbreviations like oz. and viz.)  Some others 
+# are a little appealing too.
+
+<Multi_key> <A> <ampersand> <A> :	"Ꜳ"	UA732		# LATIN CAPITAL LETTER AA
+<Multi_key> <a> <ampersand> <a> :	"ꜳ"	UA733		# LATIN SMALL LETTER AA
+<Multi_key> <2> <A> :	"Ꜳ"	UA732		# LATIN CAPITAL LETTER AA
+<Multi_key> <2> <a> :	"ꜳ"	UA733		# LATIN SMALL LETTER AA
+<Multi_key> <A> <ampersand> <O>	:	"Ꜵ"	UA734	# LATIN CAPITAL LETTER AO
+<Multi_key> <a> <ampersand> <o>	:	"ꜵ"	UA735	# LATIN SMALL LETTER AO
+<Multi_key> <A> <ampersand> <U>	:	"Ꜷ"	UA736	# LATIN CAPITAL LETTER AU
+<Multi_key> <a> <ampersand> <u>	:	"ꜷ"	UA737	# LATIN SMALL LETTER AU
+<Multi_key> <A> <ampersand> <V> :	"Ꜹ"	UA738	# LATIN CAPITAL LETTER AV
+<Multi_key> <a> <ampersand> <v> :	"ꜹ"	UA739	# LATIN SMALL LETTER AV
+<Multi_key> <A> <ampersand> <Y> :	"Ꜽ"	UA73C	# LATIN CAPITAL LETTER AY
+<Multi_key> <a> <ampersand> <y> :	"ꜽ"	UA73D	# LATIN SMALL LETTER AY
+<Multi_key> <slash> <ampersand> <L> :	"Ꝇ"	UA746	# LATIN CAPITAL LETTER BROKEN L
+<Multi_key> <slash> <ampersand> <l> :	"ꝇ"	UA747	# LATIN SMALL LETTER BROKEN L
+# (See above for reason behind keystrokes)
+<Multi_key> <Z> <period>	:	"Ꝫ"	UA76A	# LATIN CAPITAL LETTER ET
+<Multi_key> <z> <period>	:	"ꝫ"	UA76B	# LATIN SMALL LETTER ET
+<Multi_key> <V> <ampersand> <Y>	:	"Ꝡ"	UA760	# LATIN CAPITAL LETTER VY
+<Multi_key> <v> <ampersand> <y>	:	"ꝡ"	UA761	# LATIN SMALL LETTER VY
+<Multi_key> <C> <Z>	    	:	"Ꝣ"	UA762	# LATIN CAPITAL LETTER VISIGOTHIC Z
+<Multi_key> <c> <z>		:	"ꝣ"	UA763	# LATIN SMALL LETTER VISIGOTHIC Z
+<Multi_key> <L> <ampersand> <L>	:	"Ỻ"	U1EFA	# LATIN CAPITAL LETTER MIDDLE-WELSH LL
+<Multi_key> <l> <ampersand> <l>	:	"ỻ"	U1EFB	# LATIN SMALL LETTER MIDDLE-WELSH LL
+<Multi_key> <V> <ampersand> <V>	:	"Ỽ"	U1EFC	# LATIN CAPITAL LETTER MIDDLE-WELSH V
+<Multi_key> <v> <ampersand> <v>	:	"ỽ"	U1EFD	# LATIN SMALL LETTER MIDDLE-WELSH V
+<Multi_key> <d> <ampersand> <b>	:	"ȸ"	U0238	# LATIN SMALL LETTER DB DIGRAPH
+<Multi_key> <q> <ampersand> <p>	:	"ȹ"	U0239	# LATIN SMALL LETTER QP DIGRAPH
+<Multi_key> <w> <y>	    	:	"ƿ"	U01BF	# LATIN LETTER WYNN
+<Multi_key> <W> <Y>		:	"Ƿ"	U01F7	# LATIN CAPITAL LETTER WYNN
+<Multi_key> <O> <U>		:	"Ȣ"	U0222	# LATIN CAPITAL LETTER OU
+<Multi_key> <o> <u>		:	"ȣ"	U0223	# LATIN SMALL LETTER OU
+<Multi_key> <y> <r>		:	"Ʀ"	U01A6	# LATIN LETTER YR
+# <o><r> might almost make more sense, as it's used when r follows [opb].
+# But it conflicts with system ®
+<Multi_key> <r> <o>             :       "ꝛ"     UA75B   # LATIN SMALL LETTER R ROTUNDA
+<Multi_key> <r> <0>             :       "ꝛ"     UA75B   # LATIN SMALL LETTER R ROTUNDA
+# Alas, <R><O> conflicts with ® anyway.
+<Multi_key> <R> <O>             :       "Ꝛ"     UA75A   # LATIN CAPITAL LETTER R ROTUNDA
+# something, anyway.
+<Multi_key> <R> <0>             :       "Ꝛ"     UA75A   # LATIN CAPITAL LETTER R ROTUNDA
+# Custom additions: Mathematical symbols
+<Multi_key> <exclam> <equal>		: "≠"	U2260		# NOT EQUAL TO
+<Multi_key> <slash> <equal>		: "≠"	U2260		# NOT EQUAL TO
+<Multi_key> <less> <equal>		: "≤"	U2264		# LESS-THAN OR EQUAL TO
+<Multi_key> <greater> <equal>		: "≥"	U2265		# GREATER-THAN OR EQUAL TO
+<Multi_key> <exclam> <less> <greater>   : "≸"	U2278		# NEITHER LESS-THAN NOR GREATER-THAN
+# MUCH is usually enough for me.  No need for VERY.
+<Multi_key> <plus> <less>        	: "≪"	U226A		# MUCH LESS-THAN
+<Multi_key> <plus> <greater> 		: "≫"	U226B		# MUCH GREATER-THAN
+# Damn.  That makes this conflict with the standard plus plus -> #
+<Multi_key> <plus> <plus> <less>        : "⋘"	U22D8		# VERY MUCH LESS-THAN
+<Multi_key> <plus> <plus> <greater>  	: "⋙"	U22D9		# VERY MUCH GREATER-THAN
+<Multi_key> <3> <greater> 		: "⋙"	U22D9		# VERY MUCH GREATER-THAN
+<Multi_key> <3> <less>			: "⋘"	U22D8		# VERY MUCH LESS-THAN
+<Multi_key> <i> <n>			: "∈"	U2208		# ELEMENT OF
+<Multi_key> <exclam> <i> <n>		: "∉"	U2209		# NOT AN ELEMENT OF
+<Multi_key> <U2208> <slash>		: "∉"	U2209		# NOT AN ELEMENT OF (I have ∈ on my keyboard...)
+<Multi_key> <period> <U2208>            : "∊"   U220A    # SMALL ELEMENT OF
+<Multi_key> <period> <U220B>            : "∍"   U220D    # SMALL CONTAINS AS MEMBER
+# For the above for people without ∈/∋ on their kbds?  {♫i/n} and {♫n/i}?
+<Multi_key> <n> <i>			: "∋"	U220B		# CONTAINS AS MEMBER  (I hope this doesn't conflict)
+<Multi_key> <slash> <n> <i>		: "∌"	U220C		# DOES NOT CONTAIN AS MEMBER
+# <exclam><n><i> would conflict, with <exclam> <n> for N WITH UNDERDOT, etc.
+<Multi_key> <U220B> <slash>		: "∌"	U220C		# DOES NOT CONTAIN AS MEMBER
+<Multi_key> <asciitilde> <equal>			: "≅"	U2245		# APPROXIMATELY EQUAL TO (It actually means "congruent"!)
+<Multi_key> <equal> <question>		: "≟"	U225f		# QUESTIONED EQUAL TO
+<Multi_key> <equal> <d> <e> <f>		: "≝"	U225D		# EQUAL TO BY DEFINITION
+<Multi_key> <d> <e> <f> <equal>		: "≝"	U225D		# EQUAL TO BY DEFINITION
+<Multi_key> <equal> <equal>		: "≡"	U2261		# IDENTICAL TO
+<Multi_key> <colon> <equal> 		: "≔"  U2254		# COLON EQUALS
+<Multi_key> <equal> <colon> 		: "≕"  U2255		# EQUALS COLON
+<Multi_key> <2> <equal>                 : "⩵"  U2A75            # TWO CONSECUTIVE EQUALS SIGNS
+<Multi_key> <equal> <ampersand> <equal> : "⩵"  U2A75            # TWO CONSECUTIVE EQUALS SIGNS
+<Multi_key> <3> <equal>                 : "⩶"  U2A76            # THREE CONSECUTIVE EQUALS SIGNS
+# Using <slash> conflicts.
+<Multi_key> <equal> <bar> <equal>	: "≢"	U2262		# NOT IDENTICAL TO
+# We already have ±
+<Multi_key> <minus> <plus>		: "∓"	U2213		# MINUS OR PLUS SIGN
+<Multi_key> <s> <q>			: "√"	U221A		# SQUARE ROOT
+# keystrokes might not make the most sense, but you know what they mean...
+<Multi_key> <3> <s> <q>			: "∛"	U221B	        # CUBE ROOT
+<Multi_key> <4> <s> <q>			: "∜"	U221C		# FOURTH ROOT
+    # “(Note: I had put the backslash in position 5/15. It enabled the
+    # ALGOL “and” to be “/\” and the “or” to be “\/”.)” --- Bob Bemer,
+    # http://home.ccil.org/~remlaps/www.bobbemer.com/BRACES.HTM, quoting
+    # himself in “A view of the history of the ISO character code”, 1972
+<Multi_key> <slash> <backslash>         : "∧"  U2227           # LOGICAL AND
+<Multi_key> <backslash> <slash>         : "∨"  U2228           # LOGICAL OR
+<Multi_key> <backslash> <underscore> <slash>    : "⊻" U22BB     # XOR
+<Multi_key> <minus> <comma>	     :	"¬"	U00AC 		# NOT SIGN
+<Multi_key> <Multi_key> <asterisk> <o>              : "∘"   U2218           # RING OPERATOR (function composition)
+<Multi_key> <Multi_key> <asterisk> <x>             : "⨯"   U2A2F           # CROSS PRODUCT
+<Multi_key> <Multi_key> <asterisk>  <period>        : "⋅"   U22C5           # DOT OPERATOR (dot product)
+<Multi_key> <0> <slash>                 : "∅"   U2205           # EMPTY SET (thanks jsled!)
+<Multi_key> <slash> <0>                 : "∅"   U2205           # EMPTY SET
+# I'm hoping { can work as a set mnemonic
+<Multi_key> <braceleft> <U>		: "∪"	U222A		# UNION
+<Multi_key> <braceleft> <asciicircum>	: "∩"	U2229		# INTERSECTION
+<Multi_key> <braceleft> <parenleft>	: "⊂"	U2282		# SUBSET OF
+<Multi_key> <braceleft> <equal> <parenleft> : "⊆" U2286		# SUBSET OF OR EQUAL TO
+<Multi_key> <exclam> <braceleft> <parenleft> : "⊄" U2284        # NOT A SUBSET OF
+<Multi_key> <slash> <braceleft> <parenleft>  : "⊄" U2284        # NOT A SUBSET OF
+<Multi_key> <exclam> <braceleft> <parenright> :  "⊅" U2285      # NOT A SUPERSET OF
+<Multi_key> <slash> <braceleft> <parenright>  :  "⊅" U2285       # NOT A SUPERSET OF
+<Multi_key> <braceleft>	<parenright>	: "⊃"	U2283		# SUPERSET OF
+<Multi_key> <braceleft> <equal> <parenright> : "⊇" U2287	# SUPERSET OF OR EQUAL TO
+<Multi_key> <E> <E>                     : "∃"  U2203           # THERE EXISTS
+# We can't use ! E E, because ! E maps to E-WITH-UNDERDOT.
+<Multi_key> <slash> <E> <E>             : "∄"   U2204           # THERE DOES NOT EXIST
+<Multi_key> <A> <A>                     : "∀"  U2200           # FOR ALL
+<Multi_key> <Multi_key> <Q> <E> <D>     : "∎"   U220E           # END OF PROOF
+<Multi_key> <8> <8>                     : "∞"  U221E           # INFINITY
+<Multi_key> <Multi_key> <a> <l> <e> <p> <h> : "ℵ" U2135	       # ALEF SYMBOL
+<Multi_key> <Multi_key> <a> <l> <e> <p> <0> : "ℵ₀"        # ALEF Null
+<Multi_key> <Multi_key> <a> <l> <e> <p> <1> : "ℵ₁"        # ALEF One
+<Multi_key> <Multi_key> <a> <l> <e> <f> : "ℵ" U2135	       # ALEF SYMBOL
+<Multi_key> <KP_Multiply> <KP_Multiply>    : "∗"   U2217 # ASTERISK OPERATOR
+<Multi_key> <parenleft> <plus> <parenright>     : "⊕"  U2295    # CIRCLED PLUS
+<Multi_key> <parenleft> <minus> <parenright>    : "⊖"  U2296    # CIRCLED MINUS
+<Multi_key> <parenleft> <x> <x> <parenright>    : "⊗"  U2297    # CIRCLED TIMES
+<Multi_key> <parenleft> <slash> <parenright>    : "⊘"  U2298    # CIRCLED DIVISION SLASH
+<Multi_key> <parenleft> <asterisk> <parenright> : "⊛"  U229B    # CIRCLED ASTERISK OPERATOR
+# )- conflicts with system for }.
+<Multi_key> <parenright> <underscore>    : "⟌"   	U27CC		# LONG DIVISION
+<Multi_key> <period> <quotedbl>	   	: "∴"	U2234  		# THEREFORE
+<Multi_key> <Multi_key> <t> <h> <e> <r> <e> <4> : "∴"  U2234    # THEREFORE
+<Multi_key> <quotedbl> <period>	   	: "∵"	U2235  		# BECAUSE
+<Multi_key> <Multi_key> <b> <e> <c> <a> <u> <s> <e>	   	: "∵"	U2235  		# BECAUSE
+<Multi_key> <percent> <percent>		: "‱"	U2031	# PER TEN THOUSAND (basis points)
+<Multi_key> <slash> <u>                : "µ"   U00B5      # MICRO SIGN
+# Ordinal indicators, for femenine and masculine, used in Romance languages
+<Multi_key> <minus> <a>	      	  	: "ª"   U00AA		# FEMININE ORDINAL INDICATOR
+<Multi_key> <minus> <o>			: "º"	U00BA		# MASCULINE ORDINAL INDICATOR
+
+# See also U03A3 (Greek capital sigma)
+<Multi_key> <Multi_key> <s> <u> <m>	: "∑"	U2211		# N-ARY SUMMATION
+# OK, absolutely cannot believe we made it this long without NABLA or INTEGRAL
+# or PARTIAL DIFFERENTIAL
+<Multi_key> <Multi_key> <i> <n> <t>	: "∫"	U222B		# INTEGRAL
+<Multi_key> <Multi_key> <u> <i> <n> <t>	: "⨛"	U2A1B		# UPPER INTEGRAL
+<Multi_key> <Multi_key> <l> <i> <n> <t>	: "⨜"	U2A1C		# LOWER INTEGRAL
+<Multi_key> <Multi_key> <i> <i> <n> <t>	: "∬"	U222C		# DOUBLE INTEGRAL
+<Multi_key> <Multi_key> <i> <i> <i> <n> <t>	: "∭"	U222D		# TRIPLE INTEGRAL
+<Multi_key> <Multi_key> <i> <i> <i> <i> <n> <t>	: "⨌"	U2A0C		# QUADRUPLE INTEGRAL
+<Multi_key> <Multi_key> <o> <i> <n> <t>	: "∮"	U222E		# CONTOUR INTEGRAL
+<Multi_key> <Multi_key> <p> <i> <n> <t>	: "⨕"	U2A15		# INTEGRAL AROUND A POINT OPERATOR
+<Multi_key> <Multi_key> <c> <P> <i> <n> <t>	: "⨓"	U2A13		# LINE INTEGRATION WITH SEMICIRCULAR PATH AROUND POLE
+<Multi_key> <Multi_key> <o> <i> <i> <n> <t>	: "∯"	U222F		# SURFACE INTEGRAL
+<Multi_key> <Multi_key> <o> <i> <i> <i> <n> <t>	: "∰"	U2230		# VOLUME INTEGRAL
+<Multi_key> <Multi_key> <g> <i> <n> <t>	: "⨘"	U2A18		# GEOMETRIC INTEGRAL
+<Multi_key> <Multi_key> <s> <i> <n> <t>	: "⨋"	U2A0B		# SUM/INTEGRAL
+#Now for some WTF integrals: ⨙ ⨚ 	
+<Multi_key> <Multi_key> <d> <e> <l>	: "∇"	U2207	        # NABLA
+<Multi_key> <Multi_key> <p> <a> <r> <t>   : "∂" U2202		# PARTIAL DIFFERENTIAL
+<Multi_key> <asterisk> <period> <period> <d>   : "∂" U2202	# PARTIAL DIFFERENTIAL
+<Multi_key> <R> <e>    		: "ℜ"	 U211C 	     	# BLACK-LETTER CAPITAL R (Real Part)
+<Multi_key> <I> <m>		: "ℑ"	 U2111		# BLACK-LETTER CAPTIAL I (Imaginary Part)
+<Multi_key> <Multi_key> <h> <b> <a> <r>	:   "ℏ"	U210F	# PLANCK CONSTANT OVER TWO PI
+<Multi_key> <h> <minus>			:   "ℏ"	U210F	# PLANCK CONSTANT OVER TWO PI
+<Multi_key> <h> <p>	    :	"ℎ"	    U210E   # PLANCK CONSTANT
+<Multi_key> <Multi_key> <e> <x> <p> :   "ℯ"	U212F   # SCRIPT SMALL E
+<Multi_key> <e> <1> <0> :	"⏨" 	U23E8   # DECIMAL EXPONENT SYMBOL
+<Multi_key> <w> <p> 	:	"℘"	U2118	# SCRIPT CAPITAL P
+# Would we prefer 20D1 COMBINING RIGHT HARPOON ABOVE?
+<Multi_key> <asciicircum> <greater>     : "⃗"   U20D7           # COMBINING RIGHT ARROW ABOVE (vector)
+<Multi_key> <bar> <C>                   : "ℂ"   U2102           # DOUBLE-STRUCK CAPITAL C (set of complex numbers)
+<Multi_key> <bar> <N>                   : "ℕ"   U2115           # DOUBLE-STRUCK CAPITAL N (natural number)
+<Multi_key> <bar> <P>                   : "ℙ"   U2119           # DOUBLE-STRUCK CAPITAL P 
+<Multi_key> <bar> <Q>                   : "ℚ"   U211A           # DOUBLE-STRUCK CAPITAL Q (set of rational numbers)
+<Multi_key> <bar> <R>                   : "ℝ"   U211D           # DOUBLE-STRUCK CAPITAL R (set of real numbers)
+<Multi_key> <bar> <Z>                   : "ℤ"   U2124           # DOUBLE-STRUCK CAPITAL Z (set of integers)
+<Multi_key> <bar> <H>		: "ℍ" U210d	# DOUBLE-STRUCK CAPITAL H
+<Multi_key> <bar> <e>		: "ⅇ" U2147	# DOUBLE-STRUCK ITALIC SMALL E
+<Multi_key> <bar> <i>		: "ⅈ" U2148	# DOUBLE-STRUCK ITALIC SMALL I
+<Multi_key> <bar> <j>		: "ⅉ" U2149	# DOUBLE-STRUCK ITALIC SMALL J
+<Multi_key> <bar> <asterisk> <p> : "ℼ" U213C	# DOUBLE-STRUCK SMALL PI
+<Multi_key> <bar> <Greek_pi> 	 : "ℼ" U213C	# DOUBLE-STRUCK SMALL PI
+<Multi_key> <bar> <asterisk> <P> : "ℿ" U213F	# DOUBLE-STRUCK CAPITAL PI
+<Multi_key> <bar> <Greek_PI> 	 : "ℿ" U213F	# DOUBLE-STRUCK CAPITAL PI
+<Multi_key> <bar> <asterisk> <S> : "⅀" U2140	# DOUBLE-STRUCK N-ARY SUMMATION
+<Multi_key> <bar> <Greek_SIGMA>  : "⅀" U2140	# DOUBLE-STRUCK N-ARY SUMMATION
+<Multi_key> <bar> <colon>   :	"⦂" U2982	# Z NOTATION TYPE COLON
+# Apparently it is only for historical reasons that this is not unified with
+# ⨟ U+2A1F Z NOTATION SCHEMA COMPOSITION
+<Multi_key> <bar> <semicolon>	:   "⨾"	U2A3E	# Z NOTATION RELATIONAL COMPOSITION
+# The *look* double-struck.
+<Multi_key> <bar> <braceleft>	 : "⦃" U2983	# LEFT WHITE CURLY BRACKET
+<Multi_key> <bar> <braceright>	 : "⦄" U2984	# RIGHT WHITE CURLY BRACKET 
+# ⦅⦆⦇⦈⦉⦊ too?
+# The rest of that block?  Some there may be worth it.
+# Ooh.  There are lots of nice brackets to consider: 
+# ⟅⟆⟨⟩⟪⟫⟬⟭⟮⟯⦑⦒⦓⦔⦕⦖⦗⦘⧼⧽⧘⧙⧚⧛⸢⸣⸤⸥⸨⸩「」『』
+# Others too, of course, but these to start with.  Some are likely worthy.
+<Multi_key> <S> <parenleft>  	: "⟅" U27C5 	# LEFT S-SHAPED BAG DELIMITER
+<Multi_key> <S> <parenright>	: "⟆" U27C6 	# RIGHT S-SHAPED BAG DELIMITER
+<Multi_key> <E> <bracketleft>   : "⁅" U2045     # LEFT SQUARE BRACKET WITH QUILL
+<Multi_key> <E> <bracketright>  : "⁆" U2046     # RIGHT SQUARE BRACKET WITH QUILL
+# There are a lot of angle brackets (3008/9, 27E8/9, 2329/A).  I'm deciding
+# to go with the mathematical brackets from now on, since they seem to be
+# better supported.
+<Multi_key> <less> <parenleft>	: "⟨" U27E8	# MATHEMATICAL LEFT ANGLE BRACKET
+<Multi_key> <greater> <parenright>: "⟩" U27E9	# MATHEMATICAL RIGHT ANGLE BRACKET
+<Multi_key> <bar> <bracketleft>	:   "⟦"	U27E6	# MATHEMATICAL LEFT WHITE SQUARE BRACKET
+<Multi_key> <bar> <bracketright>:   "⟧"	U27E7	# MATHEMATICAL RIGHT WHITE SQUARE BRACKET
+<Multi_key> <2> <less> <parenleft> :   "⟪"	U27EA	# MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
+<Multi_key> <2> <greater> <parenright>   :   "⟫"	U27EB	# MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+# Keystrokes inconsistent.
+<Multi_key> <bar> <bar> <parenleft>	:   "⟬"  U27EC	# MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
+<Multi_key> <bar> <bar> <parenright>:   "⟭"	U27ED	# MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
+<Multi_key> <underscore> <underscore> <parenleft> :   "⟮"  U27EE	# MATHEMATICAL LEFT FLATTENED PARENTHESIS
+<Multi_key> <underscore> <underscore> <parenright>:   "⟯"  U27EF	# MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+<Multi_key> <parenleft> <bracketleft>	:   "⦗"	U2997	# LEFT BLACK TORTOISE SHELL BRACKET
+<Multi_key> <parenright> <bracketright> :   "⦘"	U2998	# RIGHT BLACK TORTOISE SHELL BRACKET
+# Do the underlined brackets, ones with ticks, dots, etc?
+<Multi_key> <percent> <parenleft>:  "⧘"	U29D8	# LEFT WIGGLY FENCE
+<Multi_key> <percent> <parenright>: "⧙"	U29D9	# RIGHT WIGGLY FENCE
+<Multi_key> <2> <percent> <parenleft>:	"⧚" U29DA   # LEFT DOUBLE WIGGLY FENCE
+<Multi_key> <2> <percent> <parenright>:	"⧛" U29DB   # RIGHT DOUBLE WIGGLY FENCE
+<Multi_key> <parenleft> <ampersand> <parenleft>:  "⸨"  U2E28 # LEFT DOUBLE PARENTHESIS
+<Multi_key> <parenright> <ampersand> <parenright>:  "⸩"  U2E29 # RIGHT DOUBLE PARENTHESIS
+<Multi_key> <2> <parenleft>:  "⸨"  U2E28 # LEFT DOUBLE PARENTHESIS
+<Multi_key> <2> <parenright>:  "⸩"  U2E29 # RIGHT DOUBLE PARENTHESIS
+<Multi_key> <Z> <parenleft>	    : "༼"     U0F3C   # TIBETAN MARK ANG KHANG GYON
+<Multi_key> <Z> <parenright>	    : "༽"     U0F3D   # TIBETAN MARK ANG KHANG GYAS
+# I'm thinking shape-mnemonics for these, somehow:
+<Multi_key> <L> <bracketleft>       : "⌊"     U230A   # LEFT FLOOR
+<Multi_key> <L> <bracketright>	    : "⌋"     U230B   # RIGHT FLOOR
+<Multi_key> <7> <bracketleft>	    : "⌈"     U2308   # LEFT CEILING
+<Multi_key> <7> <bracketright>	    : "⌉"     U2309   # RIGHT CEILING
+# These are actually quotes, hence the mnemonic.
+<Multi_key> <7> <apostrophe>	    : "｢"     UFF62   # HALFWIDTH LEFT CORNER BRACKET
+<Multi_key> <L> <apostrophe>	    : "｣"     UFF63   # HALFWIDTH RIGHT CORNER BRACKET
+# Why am I using halfwidth though, I wonder?  And I'd also like ⌜⌝⌞⌟
+<Multi_key> <7> <quotedbl>	    : "『"    U300E   # LEFT WHITE CORNER BRACKET
+<Multi_key> <L> <quotedbl>	    : "』"    U300F   # RIGHT WHITE CORNER BRACKET
+# How about these for the "corners"?  Confusing with {L[} etc?
+# and don't forget about {L_[} which we have for ⸤
+<Multi_key> <7> <parenleft>         : "⌜"     U231C   # TOP LEFT CORNER
+<Multi_key> <7> <parenright>        : "⌝"     U231D   # TOP RIGHT CORNER
+<Multi_key> <L> <parenleft>         : "⌞"     U231E   # BOTTOM LEFT CORNER
+<Multi_key> <L> <parenright>        : "⌟"     U231F   # BOTTOM RIGHT CORNER
+<Multi_key> <parenleft> <ampersand> <parenright> :  "≬"	U226C	# BETWEEN
+<Multi_key> <l> <l>		: "ℓ" U2113	# SCRIPT SMALL L
+<Multi_key> <bracketleft> <bracketleft> : "⊏"   U228F           # SQUARE IMAGE OF
+<Multi_key> <bracketleft> <equal>       : "⊑"   U2291           # SQUARE IMAGE OF OR EQUAL TO
+<Multi_key> <bracketleft> <underscore>  : "⊑"   U2291           # SQUARE IMAGE OF OR EQUAL TO
+<Multi_key> <bracketright> <bracketright>: "⊐"  U2290           # SQUARE ORIGINAL OF
+<Multi_key> <bracketright> <equal>      : "⊒"   U2292           # SQUARE ORIGINAL OF OR EQUAL TO
+<Multi_key> <bracketright> <underscore> : "⊒"   U2292           # SQUARE ORIGINAL OF OR EQUAL TO
+# If I did more Haskell, I'd want this more:
+<Multi_key> <underscore> <bar> <underscore>:	"⊥"	 U22A5	# UP TACK (bottom) or should we use U27C2 PERPENDICULAR?
+<Multi_key> <underscore> <exclam> <underscore>:	"⊤"	 U22A4	# DOWN TACK (opposite of False)
+<Multi_key> <underscore> <greater> <underscore>:	"⊢"	 U22A2	# RIGHT TACK
+<Multi_key> <underscore> <less> <underscore>:	"⊣"	 U22A3	# LEFT TACK
+# Handy for UNIX filenames... but XXX conflicts with standard <Multi_key> <slash> <slash> → "\"
+<Multi_key> <slash> <slash>		: "⁄"	U2044	# FRACTION SLASH
+
+# The system file gives us subscript numbers, plus/minus, and parens.  But
+# there are letters missing.  It would be nice to have at least a few of them.
+
+# block U+208x
+<Multi_key> <underscore> <0>  	       : "₀"  U2080   	  # SUBSCRIPT ZERO
+<Multi_key> <underscore> <1>  	       : "₁"  U2081   	  # SUBSCRIPT ONE
+<Multi_key> <underscore> <2>  	       : "₂"  U2082   	  # SUBSCRIPT TWO
+<Multi_key> <underscore> <3>  	       : "₃"  U2083   	  # SUBSCRIPT THREE
+<Multi_key> <underscore> <4>  	       : "₄"  U2084   	  # SUBSCRIPT FOUR
+<Multi_key> <underscore> <5>  	       : "₅"  U2085   	  # SUBSCRIPT FIVE
+<Multi_key> <underscore> <6>  	       : "₆"  U2086   	  # SUBSCRIPT SIX
+<Multi_key> <underscore> <7>  	       : "₇"  U2087   	  # SUBSCRIPT SEVEN
+<Multi_key> <underscore> <8>  	       : "₈"  U2088   	  # SUBSCRIPT EIGHT
+<Multi_key> <underscore> <9>  	       : "₉"  U2089   	  # SUBSCRIPT NONE
+<Multi_key> <underscore> <plus>	       : "₊"  U208A	  # SUBSCRIPT PLUS
+<Multi_key> <underscore> <minus>       : "₋"  U208B	  # SUBSCRIPT MINUS
+<Multi_key> <underscore> <equal>           : "₌"  U208C	  # SUBSCRIPT EQUALS SIGN
+<Multi_key> <underscore> <parenleft>           : "₍"  U208D	  # SUBSCRIPT LEFT PARENTHESIS
+<Multi_key> <underscore> <parenright>           : "₎"  U208E	  # SUBSCRIPT RIGHT PARENTHESIS
+
+# block U+209x
+<Multi_key> <underscore> <a>	       : "ₐ"  U2090	  # LATIN SUBSCRIPT SMALL LETTER A
+<Multi_key> <underscore> <e>	       : "ₑ"  U2091	  # LATIN SUBSCRIPT SMALL LETTER E
+<Multi_key> <underscore> <o>	       : "ₒ"  U2092	  # LATIN SUBSCRIPT SMALL LETTER O
+<Multi_key> <underscore> <x>	       : "ₓ"  U2093	  # LATIN SUBSCRIPT SMALL LETTER X
+<Multi_key> <underscore> <h>	       : "ₕ"  U2095	  # LATIN SUBSCRIPT SMALL LETTER H
+<Multi_key> <underscore> <k>           : "ₖ"  U2096	  # LATIN SUBSCRIPT SMALL LETTER K
+<Multi_key> <underscore> <l>           : "ₗ"  U2097	  # LATIN SUBSCRIPT SMALL LETTER L
+<Multi_key> <underscore> <m>	       : "ₘ"  U2098	  # LATIN SUBSCRIPT SMALL LETTER M
+<Multi_key> <underscore> <n>	       : "ₙ"  U2099	  # LATIN SUBSCRIPT SMALL LETTER N
+<Multi_key> <underscore> <p>	       : "ₚ"  U209A	  # LATIN SUBSCRIPT SMALL LETTER P
+<Multi_key> <underscore> <s>	       : "ₛ"  U209B	  # LATIN SUBSCRIPT SMALL LETTER S
+<Multi_key> <underscore> <t>	       : "ₜ"  U209C	  # LATIN SUBSCRIPT SMALL LETTER T
+
+# subscripts in other blocks
+<Multi_key> <underscore> <i>  	       : "ᵢ"  U1D62   	  # LATIN SUBSCRIPT SMALL LETTER I
+<Multi_key> <underscore> <j>           : "ⱼ"  U2C7C	  # LATIN SUBSCRIPT SMALL LETTER J
+<Multi_key> <underscore> <r>           : "ᵣ"  U1D63       # LATIN SUBSCRIPT SMALL LETTER R
+<Multi_key> <underscore> <u>           : "ᵤ"  U1D64       # LATIN SUBSCRIPT SMALL LETTER U
+<Multi_key> <underscore> <v>           : "ᵥ"  U1D65       # LATIN SUBSCRIPT SMALL LETTER V
+<Multi_key> <underscore> <asterisk> <b> : "ᵦ"  U1D66     # GREEK SUBSCRIPT SMALL LETTER BETA
+<Multi_key> <underscore> <asterisk> <g> : "ᵧ"  U1D67     # GREEK SUBSCRIPT SMALL LETTER GAMMA
+<Multi_key> <underscore> <asterisk> <r> : "ᵨ"  U1D68     # GREEK SUBSCRIPT SMALL LETTER RHO
+<Multi_key> <underscore> <asterisk> <f> : "ᵩ"  U1D69     # GREEK SUBSCRIPT SMALL LETTER PHI
+<Multi_key> <underscore> <asterisk> <x> : "ᵪ"  U1D6A     # GREEK SUBSCRIPT SMALL LETTER CHI
+
+# Custom additions: Greek letters.  Mapping corresponds to Emacs Greek
+# input method.  Aristotle Pagaltzis informs me that this is the
+# standard Greek keyboard layout, which is good.
+<Multi_key> <asterisk> <a>		: "α"	U03B1		# GREEK SMALL LETTER ALPHA
+<Multi_key> <asterisk> <b>		: "β"	U03B2		# GREEK SMALL LETTER BETA
+<Multi_key> <asterisk> <c>		: "ψ"	U03C8		# GREEK SMALL LETTER PSI
+<Multi_key> <asterisk> <d>		: "δ"	U03B4		# GREEK SMALL LETTER DELTA
+<Multi_key> <asterisk> <e>		: "ε"	U03B5		# GREEK SMALL LETTER EPSILON
+<Multi_key> <asterisk> <f>		: "φ"	U03C6		# GREEK SMALL LETTER PHI
+<Multi_key> <asterisk> <g>		: "γ"	U03B3		# GREEK SMALL LETTER GAMMA
+<Multi_key> <asterisk> <h>		: "η"	U03B7		# GREEK SMALL LETTER ΕΤΑ
+<Multi_key> <asterisk> <i>		: "ι"	U03B9		# GREEK SMALL LETTER ΙΟΤΑ
+<Multi_key> <asterisk> <j>		: "ξ"	U03BE		# GREEK SMALL LETTER XI
+<Multi_key> <asterisk> <k>		: "κ"	U03BA		# GREEK SMALL LETTER KAPPA
+<Multi_key> <asterisk> <l>		: "λ"	U03BB		# GREEK SMALL LETTER LAMBDA
+<Multi_key> <asterisk> <m>		: "μ"	U03BC		# GREEK SMALL LETTER MU
+<Multi_key> <asterisk> <n>		: "ν"	U03BD		# GREEK SMALL LETTER NU
+<Multi_key> <asterisk> <o>		: "ο"	U03BF		# GREEK SMALL LETTER OMICRON
+<Multi_key> <asterisk> <p>		: "π"	U03C0		# GREEK SMALL LETTER PI
+# no mapping for q; in Emacs that's ";"
+# U037E GREEK QUESTION MARK is canonically equivalent to U003B SEMICOLON.
+# ... But that won't stop us from doing it anyway!!!
+<Multi_key> <asterisk> <period> <question> : ";"  U037E		# GREEK QUESTION MARK
+<Multi_key> <asterisk> <r>		: "ρ"	U03C1		# GREEK SMALL LETTER RHO
+<Multi_key> <asterisk> <s>		: "σ"	U03C3		# GREEK SMALL LETTER SIGMA
+<Multi_key> <asterisk> <t>		: "τ"	U03C4		# GREEK SMALL LETTER TAU
+<Multi_key> <asterisk> <u>		: "θ"	U03B8		# GREEK SMALL LETTER THETA
+<Multi_key> <asterisk> <v>		: "ω"	U03C9		# GREEK SMALL LETTER OMEGA
+<Multi_key> <asterisk> <w>		: "ς"	U03C2		# GREEK SMALL LETTER FINAL SIGMA
+<Multi_key> <asterisk> <x>		: "χ"	U03C7		# GREEK SMALL LETTER CHI
+<Multi_key> <asterisk> <y>		: "υ"	U03C5		# GREEK SMALL LETTER UPSILON
+<Multi_key> <asterisk> <z>		: "ζ"	U03B6		# GREEK SMALL LETTER ZETA
+
+# Capital greek letters.
+<Multi_key> <asterisk> <A>		: "Α"	U0391		# GREEK CAPITAL LETTER ALPHA
+<Multi_key> <asterisk> <B>		: "Β"	U0392		# GREEK CAPITAL LETTER BETA
+<Multi_key> <asterisk> <C>		: "Ψ"	U03A8		# GREEK CAPITAL LETTER PSI
+<Multi_key> <asterisk> <D>		: "Δ"	U0394		# GREEK CAPITAL LETTER DELTA
+<Multi_key> <asterisk> <E>		: "Ε"	U0395		# GREEK CAPITAL LETTER EPSILON
+<Multi_key> <asterisk> <F>		: "Φ"	U03A6		# GREEK CAPITAL LETTER PHI
+<Multi_key> <asterisk> <G>		: "Γ"	U0393		# GREEK CAPITAL LETTER GAMMA
+<Multi_key> <asterisk> <H>		: "Η"	U0397		# GREEK CAPITAL LETTER ΕΤΑ
+<Multi_key> <asterisk> <I>		: "Ι"	U0399		# GREEK CAPITAL LETTER ΙΟΤΑ
+<Multi_key> <asterisk> <J>		: "Ξ"	U039E		# GREEK CAPITAL LETTER XI
+<Multi_key> <asterisk> <K>		: "Κ"	U039A		# GREEK CAPITAL LETTER KAPPA
+<Multi_key> <asterisk> <L>		: "Λ"	U039B		# GREEK CAPITAL LETTER LAMBDA
+<Multi_key> <asterisk> <M>		: "Μ"	U039C		# GREEK CAPITAL LETTER MU
+<Multi_key> <asterisk> <N>		: "Ν"	U039D		# GREEK CAPITAL LETTER NU
+<Multi_key> <asterisk> <O>		: "Ο"	U039F		# GREEK CAPITAL LETTER OMICRON
+<Multi_key> <asterisk> <P>		: "Π"	U03A0		# GREEK CAPITAL LETTER PI
+# see below for Q qoppa; in Emacs Q is “:”
+<Multi_key> <asterisk> <R>		: "Ρ"	U03A1		# GREEK CAPITAL LETTER RHO
+<Multi_key> <asterisk> <S>		: "Σ"	U03A3		# GREEK CAPITAL LETTER SIGMA
+<Multi_key> <asterisk> <T>		: "Τ"	U03A4		# GREEK CAPITAL LETTER TAU
+<Multi_key> <asterisk> <U>		: "Θ"	U0398		# GREEK CAPITAL LETTER THETA
+<Multi_key> <asterisk> <V>		: "Ω"	U03A9		# GREEK CAPITAL LETTER OMEGA
+# Emacs maps W to "Σ", but I think that’s stupid
+# I think that's from the Greek keyboard.
+<Multi_key> <asterisk> <X>		: "Χ"	U03A7		# GREEK CAPITAL LETTER CHI
+<Multi_key> <asterisk> <Y>		: "Υ"	U03A5		# GREEK CAPITAL LETTER UPSILON
+<Multi_key> <asterisk> <Z>		: "Ζ"	U0396		# GREEK CAPITAL LETTER ZETA
+
+# Some archaic Greek.  If we only wanted *normal* characters we wouldn't be
+# doing this at all!
+# "period" will indicate a sort of variant of some kind; asterisk is still the "greek" marker
+<Multi_key> <asterisk> <period> <p>	: "ϖ"	U03D6		# GREEK PI SYMBOL
+# Reserving .f in case we want PHI SYMBOL.  Digamma was "w" sound anyway.
+<Multi_key> <asterisk> <period> <w>	: "ϝ"	U03DD		# GREEK SMALL LETTER DIGAMMA
+<Multi_key> <asterisk> <period> <W>	: "Ϝ"	U03DC		# GREEK CAPITAL LETTER DIGAMMA
+<Multi_key> <asterisk> <Q>	: "Ϟ"	U03DE	# GREEK LETTER QOPPA
+<Multi_key> <asterisk> <q>	: "ϟ"	U03DF	# GREEK SMALL LETTER QOPPA
+<Multi_key> <asterisk> <period> <Q>	: "Ϙ"	U03D8	# GREEK LETTER ARCHAIC QOPPA
+<Multi_key> <asterisk> <period> <q>	: "ϙ"	U03D9	# GREEK SMALL LETTER ARCHAIC QOPPA
+<Multi_key> <asterisk> <ampersand>	: "ϗ"	U03D7	# GREEK KAI SYMBOL
+<Multi_key> <asterisk> <period> <Z>	: "Ϡ"	U03E0	# GREEK LETTER SAMPI
+<Multi_key> <asterisk> <period> <z>	: "ϡ"	U03E1	# GREEK SMALL LETTER SAMPI
+<Multi_key> <asterisk> <period> <period> <Z> : "Ͳ"  U0372  # GREEK CAPITAL LETTER ARCHAIC SAMPI
+<Multi_key> <asterisk> <period> <period> <z> : "ͳ"  U0373  # GREEK SMALL LETTER ARCHAIC SAMPI
+# Sorry, couldn't think of better ones for these.  Might want .s for SAN.
+<Multi_key> <asterisk> <question>      : "Ϛ"	U03DA	# GREEK LETTER STIGMA
+<Multi_key> <asterisk> <slash>	       : "ϛ"	U03DB	# GREEK SMALL LETTER STIGMA
+<Multi_key> <asterisk> <apostrophe>    : "ʹ"	U02B9	# MODIFIER LETTER PRIME, canonically equivalent to U0374 GREEK NUMERAL SIGN
+# While we're at it...
+<Multi_key> <asterisk> <period> <apostrophe>	: "′"	U2032	# PRIME
+<Multi_key> <asterisk> <period> <quotedbl>      : "″"	U2033	# DOUBLE PRIME
+<Multi_key> <asterisk> <comma>	       : "͵"	U0375	# GREEK LOWER NUMERAL SIGN (for thousands)
+# Do we want BETA SYMBOL, RHO SYMBOL, KAPPA SYMBOL, PHI SYMBOL, THETA SYMBOL?
+# The format makes them obvious enough I guess.  PI SYMBOL is different enough
+# that there's no question, and it is separate from these.
+<Multi_key> <asterisk> <period> <b>    : "ϐ"	U03D0	# GREEK BETA SYMBOL
+<Multi_key> <asterisk> <period> <u>    : "ϑ"	U03D1	# GREEK THETA SYMBOL
+<Multi_key> <asterisk> <period> <Y>    : "ϒ"	U03D2	# GREEK UPSILON WITH HOOK SYMBOL
+<Multi_key> <asterisk> <period> <f>    : "ϕ"	U03D5	# GREEK PHI SYMBOL
+<Multi_key> <asterisk> <period> <k>    : "ϰ"	U03F0	# GREEK KAPPA SYMBOL
+<Multi_key> <asterisk> <period> <r>    : "ϱ"	U03F1	# GREEK RHO SYMBOL
+<Multi_key> <asterisk> <period> <U>    : "ϴ"	U03F4	# GREEK CAPITAL THETA SYMBOL
+<Multi_key> <asterisk> <period> <e>    : "ϵ"	U03F5	# GREEK LUNATE EPSILON SYMBOL
+# Not doing the lunate sigmas and dotted versions thereof...  What about SAN, which is at least a letter?
+<Multi_key> <asterisk> <period> <s>	 : "ϻ"	  U03FB	      # GREEK SMALL LETTER SAN
+<Multi_key> <asterisk> <period> <S>	 : "Ϻ"	  U03FA	      # GREEK CAPITAL LETTER SAN
+
+# If you wanted to actually type in Greek, you would also need άίέ
+# etc.  But you would probably just switch to a Greek keyboard layout.
+
+# Custom additions: fractions
+<Multi_key> <1> <3>                     : "⅓"  U2153           # VULGAR FRACTION ONE THIRD
+<Multi_key> <2> <3>                     : "⅔"  U2154           # VULGAR FRACTION TWO THIRDS
+# more extensive fractions from jsled
+<Multi_key> <1> <5>                     : "⅕"  U2155           # VULGAR FRACTION ONE FIFTH
+<Multi_key> <2> <5>                     : "⅖" U2156            # VULGAR FRACTION TWO FIFTHS
+<Multi_key> <3> <5>                     : "⅗" U2157            # VULGAR FRACTION THREE FIFTHS
+<Multi_key> <4> <5>                     : "⅘" U2158            # VULGAR FRACTION FOUR FIFTHS
+<Multi_key> <1> <6>                     : "⅙" U2159            # VULGAR FRACTION ONE SIXTH
+<Multi_key> <5> <6>                     : "⅚" U215A            # VULGAR FRACTION FIVE SIXTHS
+<Multi_key> <1> <8>                     : "⅛" U215B           # VULGAR FRACTION ONE EIGHTH
+<Multi_key> <3> <8>                     : "⅜" U215C           # VULGAR FRACTION THREE EIGHTHS
+<Multi_key> <5> <8>                     : "⅝" U215D           # VULGAR FRACTION FIVE EIGHTHS
+<Multi_key> <7> <8>                     : "⅞" U215E           # VULGAR FRACTION SEVEN EIGHTHS
+<Multi_key> <1> <7>			: "⅐" U2150	      # VULGAR FRACTION ONE SEVENTH
+<Multi_key> <1> <9>			: "⅑" U2151	      # VULGAR FRACTION ONE NINTH
+<Multi_key> <1> <x>			: "⅒" U2152	      # VULGAR FRACTION ONE TENTH
+<Multi_key> <0> <3>			: "↉" U2189	      # VULGAR FRACTION ZERO THIRDS
+<Multi_key> <1> <slash>			: "⅟" U215F	      # FRACTION NUMERATOR ONE
+
+# How about roman numerals?  Percent for numerical mnemonic?
+# Does this go against the spirit of this file?  These symbols are accessible 
+# as regular letters and would look okay.  Maybe only for I-X?
+<Multi_key> <percent> <1>		: "ⅰ"	U2170		# SMALL ROMAN NUMERAL ONE
+<Multi_key> <percent> <2>		: "ⅱ"	U2171		# SMALL ROMAN NUMERAL TWO
+<Multi_key> <percent> <3>		: "ⅲ"	U2172		# SMALL ROMAN NUMERAL THREE
+<Multi_key> <percent> <4>		: "ⅳ"	U2173		# SMALL ROMAN NUMERAL FOUR
+<Multi_key> <percent> <5>		: "ⅴ"	U2174		# SMALL ROMAN NUMERAL FIVE
+<Multi_key> <percent> <6>		: "ⅵ"	U2175		# SMALL ROMAN NUMERAL SIX
+<Multi_key> <percent> <7>		: "ⅶ"	U2176		# SMALL ROMAN NUMERAL SEVEN
+<Multi_key> <percent> <8>		: "ⅷ"	U2177		# SMALL ROMAN NUMERAL EIGHT
+<Multi_key> <percent> <9>		: "ⅸ"	U2178		# SMALL ROMAN NUMERAL NINE
+<Multi_key> <percent> <x>		: "ⅹ"	U2179		# SMALL ROMAN NUMERAL TEN
+# How do we handle eleven and twelve?
+<Multi_key> <percent> <underscore> <1>	: "ⅺ"	U217A		# SMALL ROMAN NUMERAL ELEVEN
+<Multi_key> <percent> <underscore> <2>	: "ⅻ"	U217B		# SMALL ROMAN NUMERAL TWELVE
+# That okay?
+<Multi_key> <percent> <l>		: "ⅼ"	U217C		# SMALL ROMAN NUMERAL FIFTY
+<Multi_key> <percent> <c>		: "ⅽ"	U217D		# SMALL ROMAN NUMERAL ONE HUNDRED
+<Multi_key> <percent> <d>		: "ⅾ"	U217E		# SMALL ROMAN NUMERAL FIVE HUNDRED
+<Multi_key> <percent> <m>		: "ⅿ"	U217F		# SMALL ROMAN NUMERAL ONE THOUSAND
+###
+<Multi_key> <percent> <0> <1>		: "Ⅰ"	U2160		# ROMAN NUMERAL ONE
+<Multi_key> <percent> <0> <2>		: "Ⅱ"	U2161		# ROMAN NUMERAL TWO
+<Multi_key> <percent> <0> <3>		: "Ⅲ"	U2162		# ROMAN NUMERAL THREE
+<Multi_key> <percent> <0> <4>		: "Ⅳ"	U2163		# ROMAN NUMERAL FOUR
+<Multi_key> <percent> <0> <5>		: "Ⅴ"	U2164		# ROMAN NUMERAL FIVE
+<Multi_key> <percent> <0> <6>		: "Ⅵ"	U2165		# ROMAN NUMERAL SIX
+<Multi_key> <percent> <0> <7>		: "Ⅶ"	U2166		# ROMAN NUMERAL SEVEN
+<Multi_key> <percent> <0> <8>		: "Ⅷ"	U2167		# ROMAN NUMERAL EIGHT
+<Multi_key> <percent> <0> <9>		: "Ⅸ"	U2168		# ROMAN NUMERAL NINE
+<Multi_key> <percent> <0> <x>		: "Ⅹ"	U2169		# ROMAN NUMERAL TEN
+# How do we handle eleven and twelve?
+<Multi_key> <percent> <underscore> <0> <1>	: "Ⅺ"	U216A	# ROMAN NUMERAL ELEVEN
+<Multi_key> <percent> <underscore> <0> <2>	: "Ⅻ"	U216B	# ROMAN NUMERAL TWELVE
+<Multi_key> <percent> <0> <l>		: "Ⅼ"	U216C		# ROMAN NUMERAL FIFTY
+<Multi_key> <percent> <0> <c>		: "Ⅽ"	U216D		# ROMAN NUMERAL ONE HUNDRED
+<Multi_key> <percent> <0> <d>		: "Ⅾ"	U216E		# ROMAN NUMERAL FIVE HUNDRED
+<Multi_key> <percent> <0> <m>		: "Ⅿ"	U216F		# ROMAN NUMERAL ONE THOUSAND
+<Multi_key> <percent> <X>		: "Ⅹ"	U2169		# ROMAN NUMERAL TEN
+<Multi_key> <percent> <L>		: "Ⅼ"	U216C		# ROMAN NUMERAL FIFTY
+<Multi_key> <percent> <C>		: "Ⅽ"	U216D		# ROMAN NUMERAL ONE HUNDRED
+<Multi_key> <percent> <less> <C>        : "Ↄ"   U2183          # ROMAN NUMERAL REVERSED ONE HUNDRED
+<Multi_key> <percent> <D>		: "Ⅾ"	U216E		# ROMAN NUMERAL FIVE HUNDRED
+<Multi_key> <percent> <M>		: "Ⅿ"	U216F		# ROMAN NUMERAL ONE THOUSAND
+<Multi_key> <percent> <0> <C> <D>	: "ↀ"	U2180		# ROMAN NUMERAL ONE THOUSAND C D
+<Multi_key> <percent> <0> <D> 		: "ↁ"	U2181		# ROMAN NUMERAL FIVE THOUSAND
+<Multi_key> <percent> <0> <M>		: "ↂ"	U2182		# ROMAN NUMERAL TEN THOUSAND
+<Multi_key> <percent> <0> <0> <D>	: "ↇ"	U2187		# ROMAN NUMERAL FIFTY THOUSAND
+<Multi_key> <percent> <0> <0> <M>	: "ↈ"	U2188		# ROMAN NUMERAL ONE HUNDRED THOUSAND
+
+
+# Custom additions: for chat (kragen)
+<Multi_key> <parenleft> <colon>         : "☻"   U263B           # BLACK SMILING FACE
+<Multi_key> <colon> <parenright>        : "☺"   U263A           # WHITE SMILING FACE
+<Multi_key> <colon> <parenleft>         : "☹"   U2639           # WHITE FROWNING FACE
+<Multi_key> <colon> <asciitilde>	: "⍨"   U2368		# APL FUNCTIONAL SYMBOL TILDE DIAERESIS
+<Multi_key> <colon> <bar>		: "⸚"   U2E1A		# HYPHEN WITH DIAERESIS
+<Multi_key> <colon> <o> <o> <parenright>  :  "°͜°"    # Funny smiley-face.
+# Those are archaic cyrilic letters... but look so _perfect_ for use
+# in chat. And about the last, the "multiocular O"... Well, I don't
+# know what it can be used for, but given the description, how could I
+# leave it out‽
+# (I guess using U+1F440 EYES would be more straightforward, but not as funny?)
+<Multi_key> <O> <period> <O>		: "Ꙭ"	UA66C		# CYRILLIC CAPITAL LETTER DOUBLE MONOCULAR O * used in the dual of words based on the root for 'eye'
+<Multi_key> <o> <period> <o>		: "ꙭ"  UA66D		# CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
+<Multi_key> <O> <colon>	 		: "Ꙫ"  UA66A		# CYRILLIC CAPITAL LETTER BINOCULAR O * used in the dual of words based on the root for 'eye'
+<Multi_key> <o> <colon> 		: "ꙫ"  UA66B 		# CYRILLIC SMALL LETTER BINOCULAR O
+<Multi_key> <o> <plus>			: "ꙮ"  UA66E		# CYRILLIC LETTER MULTIOCULAR O * used in the epithet 'many-eyed'
+# While we're doing stacks of circles with dots.
+<Multi_key> <o> <3>			: "߷"	U07F7		# NKO SYMBOL GBAKURUNEN
+<Multi_key> <exclam> <question>         : "‽"   U203D           # INTERROBANG
+<Multi_key> <question> <exclam>         : "⸘"	U2E18		# INVERTED INTERROBANG, standard now.
+<Multi_key> <questiondown> <exclamdown>	: "⸘"	U2E18		# INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? "?i" maybe?
+<Multi_key> <exclamdown> <questiondown>	: "⸘"	U2E18		# INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? "?i" maybe?
+<Multi_key> <question> <less>	      : "⸮"	  U2E2E		# REVERSED QUESTION MARK
+<Multi_key> <question> <BackSpace>      : "⸮"	  U2E2E		# REVERSED QUESTION MARK
+<Multi_key> <question> <ampersand> <question>	  : "⁇"	 U2047	# DOUBLE QUESTION MARK
+<Multi_key> <2> <question>	  : "⁇"	 U2047	# DOUBLE QUESTION MARK
+<Multi_key> <question> <ampersand> <exclam>	  : "⁈"	 U2048	# QUESTION EXCLAMATION MARK
+<Multi_key> <exclam> <ampersand> <question>	  : "⁉"	 U2049	# EXCLAMATION QUESTION MARK
+<Multi_key> <exclam> <ampersand> <exclam>	  : "‼"	 U203C	# DOUBLE EXCLAMATION MARK
+<Multi_key> <2> <exclam>	  : "‼"	 U203C	# DOUBLE EXCLAMATION MARK
+<Multi_key> <2> <colon>		  : "∷"	 U2237	# PROPORTION -- not strictly 2 times COLON
+<Multi_key> <semicolon> <less>	 		  : "⁏"	 U204F	# REVERSED SEMICOLON
+<Multi_key> <semicolon> <BackSpace>	 		  : "⁏"	 U204F	# REVERSED SEMICOLON
+# Keep looking into big hunks of Latin Extended-D, A720- et seq.
+<Multi_key> <less> <3>                  : "♥"  U2665            # BLACK HEART SUIT
+<Multi_key> <o> <8>			: "♣" U2663		# BLACK CLUB SUIT
+<Multi_key> <c> <3>			: "♣" U2663		# BLACK CLUB SUIT
+<Multi_key> <less> <greater>		: "♢" U2662		# WHITE DIAMOND SUIT
+<Multi_key> <3> <minus>		: "♠" U2660		# BLACK SPADE SUIT
+<Multi_key> <less> <braceright>	: "♠" U2660		# BLACK SPADE SUIT
+<Multi_key> <E> <greater>		: "♡" U2661		# WHITE HEART SUIT
+# "shamrock" is too long; there IS a limit to these!
+<Multi_key> <Multi_key> <s> <h> <m> <r> <c> <k>		: "☘" U2618   # SHAMROCK
+<Multi_key> <Multi_key> <s> <h> <a> <m> <r> <o>		: "☘" U2618   # SHAMROCK
+<Multi_key> <Multi_key> <p> <c>         : "☮"   U262E           # PEACE SYMBOL
+<Multi_key> <Multi_key> <p> <e> <a> <c> <e> : "☮"   U262E           # PEACE SYMBOL
+<Multi_key> <Multi_key> <y> <y>		: "☯" U262F		# YIN YANG
+<Multi_key> <Multi_key> <y> <i>	<n> <y> <a> <n>	: "☯" U262F	# YIN YANG
+# And now that we are into hearts...
+<Multi_key> <Left> <less> <3>           : "❥"  U2765            # ROTATED HEAVY BLACK HEART BULLET
+<Multi_key> <exclam> <less> <3>         : "❣"  U2763            # HEAVY HEART EXCLAMATION MARK ORNAMENT
+<Multi_key> <f> <less> <3>              : "❦"  U2766            # FLORAL HEART
+<Multi_key> <Left> <f> <less> <3>       : "❧"  U2767            # ROTATED FLORAL HEART BULLET
+<Multi_key> <Right> <f> <less> <3>      : "☙"  U2619            # REVERSED ROTATED FLORAL HEART BULLET
+<Multi_key> <Multi_key> <t> <e> <l>			: "☎" 	U260E		# BLACK TELEPHONE
+<Multi_key> <Multi_key> <t> <e> <a>		: "☕"	U2615		# HOT BEVERAGE
+# These last two bother me less, though they can still be improved.
+# Other possibly useful symbols:
+# 2668 HOT SPRINGS (for chat, for running off to shower?)
+# I want 2713-2714 and 2717-2718
+# We need a Dingbats prefix, for ❛❜❝❞❢
+<Multi_key> <bracketleft> <space> <bracketright> :	"☐"	U2610	# BALLOT BOX
+# Better keystrokes anyone?  This one breaks the pattern. [c]? [v]? [y]? [/]?
+<Multi_key> <Multi_key> <c> <h> <k>	      :	 "☑"  U2611		# BALLOT BOX WITH CHECK
+<Multi_key> <bracketleft> <slash> <bracketright>     :	 "☑"  U2611		# BALLOT BOX WITH CHECK
+<Multi_key> <bracketleft> <x> <bracketright>  :	 "☒"  U2612		# BALLOT BOX WITH X
+# @ for dingbats?
+<Multi_key> <at> <slash>	:	"✓"	U2713	# CHECK MARK
+<Multi_key> <at> <at> <slash>	:	"✔"	U2714	# HEAVY CHECK MARK
+<Multi_key> <at> <X>  		:	"✗"	U2717	# BALLOT X
+<Multi_key> <at> <at> <X>	:	"✘"	U2718	# HEAVY BALLOT X
+<Multi_key> <at> <parenleft>    :       "❨"     U2768   # MEDIUM LEFT PARENTHESIS ORNAMENT
+<Multi_key> <at> <parenright>   :       "❩"     U2769   # MEDIUM RIGHT PARENTHESIS ORNAMENT
+<Multi_key> <at> <at> <parenleft>    :  "❪"     U276A   # MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
+<Multi_key> <at> <at> <parenright>   :  "❫"     U276B   # MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
+<Multi_key> <at> <less>         :       "❬"     U276C   # MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
+<Multi_key> <at> <greater>      :       "❭"     U276D   # MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
+# U276E&F ❮❯ ?  Angle quotation mark ornaments?
+<Multi_key> <at> <at> <less>    :       "❰"     U2770   # HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
+<Multi_key> <at> <at> <greater> :       "❱"     U2771   # HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
+<Multi_key> <at> <bracketleft> <parenleft> :    "❲"     U2772   # LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
+<Multi_key> <at> <bracketright> <parenright> :  "❳"     U2773   # LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
+<Multi_key> <at> <braceleft>    :       "❴"     U2774   # MEDIUM LEFT CURLY BRACKET ORNAMENT
+<Multi_key> <at> <braceright>   :       "❵"     U2775   # MEDIUM RIGHT CURLY BRACKET ORNAMENT
+# Will I want <at> <at> for something else?
+# Now there is such a thing as text style and emoji style.  Use the
+# "dingbat prefix" in an unusual way:
+<Multi_key> <at> <Multi_key>	:	"️"	UFE0F		# Emoji selector
+<Multi_key> <exclam> <Multi_key>	:	"︎"		UFE0E	# Text selector
+# How about dice?
+<Multi_key> <bracketleft> <1> <bracketright>  :  "⚀"  U2680	# DIE FACE-1
+<Multi_key> <bracketleft> <2> <bracketright>  :  "⚁"  U2681	# DIE FACE-2
+<Multi_key> <bracketleft> <3> <bracketright>  :  "⚂"  U2682	# DIE FACE-3
+<Multi_key> <bracketleft> <4> <bracketright>  :  "⚃"  U2683	# DIE FACE-4
+<Multi_key> <bracketleft> <5> <bracketright>  :  "⚄"  U2684	# DIE FACE-5
+<Multi_key> <bracketleft> <6> <bracketright>  :  "⚅"  U2685	# DIE FACE-6
+# 267B BLACK UNIVERSAL RECYCLING SYMBOL
+
+<Multi_key> <parenleft> <C> <C> <parenright>  :  "🅭"    U1F16D    # CIRCLED CC
+<Multi_key> <C> <parenleft> <C> <C> <parenright>  :  "🅭"    U1F16D    # CIRCLED CC
+<Multi_key> <parenleft> <backslash> <C> <parenright>  :  "🅮"    U1F16E    # CIRCLED C WITH OVERLAID BACKSLASH
+<Multi_key> <parenleft> <slash> <C> <parenright>   :  "🅮"    U1F16E    # CIRCLED C WITH OVERLAID BACKSLASH
+<Multi_key> <C> <parenleft> <backslash> <C> <parenright>  :  "🅮"    U1F16E    # CIRCLED C WITH OVERLAID BACKSLASH
+<Multi_key> <C> <parenleft> <slash> <C> <parenright>   :  "🅮"    U1F16E    # CIRCLED C WITH OVERLAID BACKSLASH
+<Multi_key> <C> <parenleft> <B> <Y> <parenright>       :  "🅯"    U1F16F    # CIRCLED HUMAN FIGURE
+<Multi_key> <C> <parenleft> <S> <A> <parenright>       :  "🄎"    U1F10E    # CIRCLED ANTICLOCKWISE ARROW
+## ugh, this doesn't (usually) match the style of the others.  They're practically emoji; ⊜ is a math symbol.
+<Multi_key> <C> <parenleft> <N> <D> <parenright>       :  "⊜"    U229C    # CIRCLED EQUALS
+<Multi_key> <C> <parenleft> <equal> <parenright>       :  "⊜"    U229C    # CIRCLED EQUALS
+<Multi_key> <C> <parenleft> <N> <C> <parenright>       :  "🄏"     U1F10F    # CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+<Multi_key> <C> <parenleft> <slash> <dollar> <parenright>       :  "🄏"     U1F10F    # CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+<Multi_key> <C> <parenleft> <backslash> <dollar> <parenright>       :  "🄏"     U1F10F    # CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+## Not actually Creative Commons, but related.  Too many options?
+<Multi_key> <parenleft> <C> <Left> <parenright>        :  "🄯"   U1F12F      # COPYLEFT SYMBOL
+<Multi_key> <parenleft> <C> <less> <parenright>        :  "🄯"   U1F12F      # COPYLEFT SYMBOL
+<Multi_key> <C> <parenleft> <C> <Left> <parenright>        :  "🄯"   U1F12F      # COPYLEFT SYMBOL
+<Multi_key> <C> <parenleft> <C> <less> <parenright>        :  "🄯"   U1F12F      # COPYLEFT SYMBOL
+
+## Segmented digits?
+<Multi_key> <numbersign> <0>    :  "🯰"  U1FBF0    # SEGMENTED DIGIT ZERO
+<Multi_key> <numbersign> <1>    :  "🯱"  U1FBF1    # SEGMENTED DIGIT ONE
+<Multi_key> <numbersign> <2>    :  "🯲"  U1FBF2    # SEGMENTED DIGIT TWO
+<Multi_key> <numbersign> <3>    :  "🯳"  U1FBF3    # SEGMENTED DIGIT THREE
+<Multi_key> <numbersign> <4>    :  "🯴"  U1FBF4    # SEGMENTED DIGIT FOUR
+<Multi_key> <numbersign> <5>    :  "🯵"  U1FBF5    # SEGMENTED DIGIT FIVE
+<Multi_key> <numbersign> <6>    :  "🯶"  U1FBF6    # SEGMENTED DIGIT SIX
+<Multi_key> <numbersign> <7>    :  "🯷"  U1FBF7    # SEGMENTED DIGIT SEVEN
+<Multi_key> <numbersign> <8>    :  "🯸"  U1FBF8    # SEGMENTED DIGIT EIGHT
+<Multi_key> <numbersign> <9>    :  "🯹"  U1FBF9    # SEGMENTED DIGIT NINE
+
+# Keystrokes okay?
+<Multi_key> <Multi_key> <f> <d> <l>   	        : "⚜"	U269C	  # FLEUR-DE-LIS
+<Multi_key> <Multi_key> <a> <t> <o> <m>	        : "⚛"	U269B		# ATOM SYMBOL
+<Multi_key> <Multi_key> <c> <c> <c> <p>		: "☭" 	U262D		# HAMMER AND SICKLE
+<Multi_key> <slash> <exclam> <backslash> : "⚠"  U26A0           # WARNING SIGN
+<Multi_key> <exclam> <asciicircum>	: "⚠"	U26A0		# WARNING SIGN 
+<Multi_key> <Multi_key> <z> <a> <p>	  		: "⚡"	U26A1		# HIGH VOLTAGE SIGN 
+# Shouldn't use just <r><a> because it's too likely to be a prefix for
+# a useful word.
+<Multi_key> <Multi_key> <r> <a> <d>	: "☢"	U2622		# RADIOACTIVE SIGN
+<Multi_key> <Multi_key> <b> <h>		: "☣"	U2623		# BIOHAZARD SIGN
+<Multi_key> <Multi_key> <b> <i> <o> <h>	<a> <z>	: "☣"	U2623		# BIOHAZARD SIGN
+# Changing this from ⚝
+<Multi_key> <Multi_key> <A> <A> <A> <A> <A>	:	"⛤" U26E4 # PENTAGRAM (pentalpha, get it?)
+<Multi_key> <Multi_key> <p> <l> <a> <n> <e>	: "✈"   U2708	  # AIRPLANE
+<Multi_key> <Multi_key> <m> <a> <i> <l>		: "✉"	U2709	  # ENVELOPE
+<Multi_key> <Multi_key> <w> <h> <l> <c> <h>	: "♿"	U267F	  # WHEELCHAIR SYMBOL
+<Multi_key> <Multi_key> <m> <e> <d> 		: "☤"	U2624	  # CADEUCEUS
+## Don't usually do sequences, but exception made for the
+## "eyewitness" compound emoji sequence:
+<Multi_key> <Multi_key> <i> <w> <i> <t>     : "👁️‍🗨️"
+# Something different for STAFF OF AESCULAPIUS?
+<Multi_key> <Multi_key> <1> <m> <e> <d>		: "⚕"	U2695	# STAFF OF AESCULAPIUS
+# 26B0 COFFIN ?
+# One of the SNOWFLAKEs?
+# SNOWMAN? COMET? ANCHOR?
+# Maybe if we go with having a "word" symbol and spelling out lots and 
+# lots of whole words, we can have all the planets.
+#
+# I already have STAR OF DAVID on another map.
+# 231A, 231B -- WATCH and HOURGLASS -- one should be &-w-a-i-t
+# 23D4 METRICAL LONG OVER TWO SHORTS a.k.a. METRICAL BOOBS
+# 0950 DEVANAGARI OM?
+# 212E ESTIMATED SYMBOL?
+# 2324 UP ARROWHEAD BETWEEN TWO HORIZONTAL BARS a.k.a. NOT AMUSED
+# 237E BELL SYMBOL a.k.a. ALIENS LANDING
+
+<Multi_key> <o> <minus> <plus>		: "♀"	U2640		# FEMALE SIGN
+<Multi_key> <o> <minus> <greater>	: "♂"	U2642		# MALE SIGN
+
+<Multi_key> <Multi_key> <g> <a> <y>                 :   "⚣"     U26A3   # DOUBLED MALE SIGN
+<Multi_key> <Multi_key> <l> <e> <s> <b> <i> <a> <n> :   "⚢"     U26A2   # DOUBLED FEMALE SIGN
+<Multi_key> <Multi_key> <h> <e> <t> <e> <r> <o>     :   "⚤"     U26A4   # INTERLOCKED FEMALE AND MALE SIGN
+
+# 'trans': short for transgender/transexual
+# 'genderq': short for genderqueer.
+# Wasn't sure which to call which symbol, and wanted to include both
+<Multi_key> <Multi_key> <t> <r> <a> <n> <s>         :   "⚥"     U26A5   # MALE AND FEMALE SIGN
+<Multi_key> <Multi_key> <g> <e> <n> <d> <e> <r> <q> :   "⚧"     U26A7   # MALE WITH STROKE AND MALE AND FEMALE SIGN
+
+
+<Multi_key> <O> <X>: 			"☠" U2620 # SKULL AND CROSSBONES
+<Multi_key> <Multi_key> <d> <e> <a> <t> <h>:	  "☠" U2620 # SKULL AND CROSSBONES
+<Multi_key> <Multi_key> <X> <b> <o> <n> <e> <s>:	  "☠" U2620 # SKULL AND CROSSBONES
+<Multi_key> <Multi_key> <k> <b> <d> :	"⌨"	  U2328	    # KEYBOARD
+<Multi_key> <Multi_key> <r> <h> <a> <n> <d>	: "☞" U261E # WHITE RIGHT POINTING INDEX
+<Multi_key> <Multi_key> <l> <h> <a> <n> <d>	: "☜" U261C # WHITE LEFT POINTING INDEX
+<Multi_key> <asterisk> <asterisk>	:"★" U2605 # BLACK STAR
+<Multi_key> <asterisk> <0>	:"☆" U2606 # WHITE STAR
+<Multi_key> <asterisk> <minus>	:"✪" U272A # CIRCLED WHITE STAR
+## Did not have great luck with keystrokes for these.  L/ conflicts with ł,
+## and </ conflicts with \.  */ of course is ϛ.
+<Multi_key> <Left> <slash> <2> <asterisk>   : "⯨"    U2BE8   # LEFT HALF BLACK STAR
+<Multi_key> <Right> <slash> <2> <asterisk>   : "⯩"   U2BE9   # RIGHT HALF BLACK STAR
+<Multi_key> <asterisk> <Left> <slash> <2> <asterisk>   : "⯪"  U2BEA   # STAR WITH LEFT HALF BLACK
+<Multi_key> <asterisk> <Right> <slash> <2> <asterisk>   : "⯫" U2BEB   # STAR WITH RIGHT HALF BLACK
+<Multi_key> <asterisk> <3>	:"⁂" U2042 # ASTERISM
+<Multi_key> <3> <asterisk>	:"⁂" U2042 # ASTERISM
+<Multi_key> <2> <asterisk>	:"⁑" U2051 # TWO ASTERISKS ALIGNED VERTICALLY
+<Multi_key> <asterisk> <4>      :"✢"  U2722  # FOUR TEARDROP-SPOKED ASTERISK
+<Multi_key> <asterisk> <6>	:"✡" U2721 # STAR OF DAVID
+<Multi_key> <asterisk> <numbersign>	:"✯" U272F # PINWHEEL STAR
+<Multi_key> <asterisk> <exclam>	:"✱" U2731 # HEAVY ASTERISK
+<Multi_key> <less> <X> <greater> :  "❖"	U2756	# BLACK DIAMOND MINUS WHITE X
+<Multi_key> <at> <numbersign>	: "⌘" U2318	# PLACE OF INTEREST SIGN
+# Using backslash-minus-slash etc. conflicts with combining accents.
+<Multi_key> <grave> <minus> <apostrophe>	 : "⚞"	U269E  # THREE LINES CONVERGING RIGHT
+<Multi_key> <apostrophe> <minus> <grave>	 : "⚟"	U269F  # THREE LINES CONVERGING LEFT
+<Multi_key> <Multi_key> <B> <e> <l> <l> <s> <y> <m>	: "⍾" U237E  # BELL SYMBOL (or ALIENS LANDING) -- &-a-l-i-e-n ?
+# Other monstery characters... ѪꙚ (alien abductions?)
+# ඏൠഋ & others from Kannada et al...?
+# Can't use -^- for this; conflicts with -^ for ↑, and getting those arrows
+# workable was complicated enough.  How about this?
+<Multi_key> <underscore> <asciicircum> <underscore>	: "⌤" U2324  # UP ARROWHEAD BETWEEN TWO HORIZONTAL BARS; aka ENTER KEY, aka NOT AMUSED.
+<Multi_key> <Multi_key> <w> <a> <i> <t>		: "⌛" U231B   # HOURGLASS
+<Multi_key> <Multi_key> <h> <o> <u> <r>		: "⌛" U231B   # HOURGLASS
+<Multi_key> <Multi_key> <t> <i> <m> <e>		: "⌚" U231A   # WATCH
+<Multi_key> <Multi_key> <w> <a> <t> <c> <h>	: "⌚" U231A   # WATCH
+<Multi_key> <space> <N>		  : " "	U2002  # EN SPACE
+<Multi_key> <space> <M>		  : " " U2003  # EM SPACE
+<Multi_key> <space> <3> <M>	  : " "	U2004  # THREE-PER-EM SPACE
+<Multi_key> <space> <4> <M>	  : " "	U2005  # FOUR-PER-EM SPACE
+<Multi_key> <space> <6> <M>	  : " "	U2006    # SIX-PER-EM SPACE
+<Multi_key> <space> <comma>	  : " "	U2008    # PUNCTUATION SPACE
+<Multi_key> <space> <plus>	  : " "	U205F    # MEDIUM MATHEMATICAL SPACE
+<Multi_key> <parenleft> <parenright>: "◌" U25CC # DOTTED CIRCLE
+<Multi_key> <bracketleft> <bracketright>: "⬚" U2B1A # DOTTED SQUARE
+<Multi_key> <asterisk> <parenleft>      : "﴾"   UFD3E           # ORNATE LEFT PARENTHESIS
+<Multi_key> <asterisk> <parenright>     : "﴿"   UFD3F           # ORNATE RIGHT PARENTHESIS
+<Multi_key> <k> <s>                     : "ʘ"   U0298           # LATIN LETTER BILABIAL CLICK (kiss sound)
+<Multi_key> <bar> <greater>             : "‣"   U2023           # TRIANGULAR BULLET
+#SUPERSCRIPTS:
+#To avoid namespace clashes, <asciicircum> is doubled (will I regret that?)
+<Multi_key> <asciicircum> <asciicircum> <h>       : "ʰ"   U02B0           # SUPERSCRIPT H
+<Multi_key> <asciicircum> <asciicircum> <i>       : "ⁱ"   U2071           # SUPERSCRIPT I
+<Multi_key> <asciicircum> <asciicircum> <j>       : "ʲ"   U02B2           # SUPERSCRIPT J
+<Multi_key> <asciicircum> <asciicircum> <n>       : "ⁿ"   U207F           # SUPERSCRIPT N
+<Multi_key> <asciicircum> <asciicircum> <r>       : "ʳ"   U02B3           # SUPERSCRIPT R
+<Multi_key> <asciicircum> <asciicircum> <w>       : "ʷ"   U02B7           # SUPERSCRIPT W
+<Multi_key> <asciicircum> <asciicircum> <y>       : "ʸ"   U02B8           # SUPERSCRIPT Y
+# How could I have gone so long without being able to type "10ˣ" for "thanks"?
+<Multi_key> <asciicircum> <asciicircum> <x>       : "ˣ"   U02E3           # SUPERSCRIPT X
+# So I can use yᵗ/þᵗ and yᵉ/þᵉ
+<Multi_key> <asciicircum> <asciicircum> <e>	  : "ᵉ"	  U1D49		  # MODIFIER LETTER SMALL E
+<Multi_key> <asciicircum> <asciicircum> <t>	  : "ᵗ"	  U1D57		  # MODIFIER LETTER SMALL T
+# Abbreviation for "that":
+<Multi_key> <U00FE> <t>	  			  : "ꝥ"	  UA765		  # LATIN SMALL LETTER THORN WITH STROKE
+#Maybe add: ˃˂  Need to be able to talk about ʔˁ...
+<Multi_key> <asciicircum> <question> <period>	: "ˀ"	U02C0	# MODIFIER LETTER GLOTTAL STOP
+<Multi_key> <asciicircum> <question> <parenleft> : "ˁ"	U02C1	# MODIFIER LETTER REVERSED GLOTTAL STOP
+<Multi_key> <asciicircum> <minus>       : "⁻"   U207B           # SUPERSCRIPT MINUS
+<Multi_key> <asciicircum> <plus>	: "⁺"	U207A		# SUPERSCRIPT PLUS
+
+<Multi_key> <asciitilde> <asciitilde>        : "≈"  U2248           # ALMOST EQUAL TO
+<Multi_key> <s> <h>			: "ʃ"	U0283		# LATIN SMALL LETTER ESH
+<Multi_key> <z> <h>			: "ʒ"	U0292		# LATIN SMALL LETTER EZH
+<Multi_key> <l> <h>    			: "ɬ"	U026C		# LATIN SMALL LETTER L WITH BELT
+<Multi_key> <l> <3>			: "ɮ"	U026E		# LATIN SMALL LETTER LEZH
+<Multi_key> <y> <g>			: "ȝ"	U021D		# LATIN SMALL LETTER YOGH
+<Multi_key> <Y> <G>			: "Ȝ"	U021C		# LATIN CAPITAL LETTER YOGH
+<Multi_key> <question> <period>		: "ʔ"	U0294		# LATIN LETTER GLOTTAL STOP
+<Multi_key> <question> <parenleft>	: "ʕ"	U0295		# LATIN LETTER PHARYNGEAL VOICED FRICATIVE
+# Not great keystrokes...
+<Multi_key> <question> <v>		: "ʖ"	U0296		# LATIN LETTER INVERTED GLOTTAL STOP
+<Multi_key> <question> <at>		: "ʖ"	U0296		# LATIN LETTER INVERTED GLOTTAL STOP
+<Multi_key> <question> <minus>		: "ʡ"	U02A1		# LATIN LETTER GLOTTAL STOP WITH STROKE
+<Multi_key> <question> <braceleft>	: "ʢ"	U02A2		# LATIN LETTER REVERSED GLOTTAL STOP WITH STROKE
+# How about ɸ? φ isn’t the IPA glyph.
+<Multi_key> <p> <h>			: "ɸ"	U0278		# LATIN SMALL LETTER PHI
+<Multi_key> <i> <h>    			: "ɪ"	U026A		# LATIN LETTER SMALL CAPITAL I
+<Multi_key> <I> <H>    			: "ɪ"	U026A		# LATIN LETTER SMALL CAPITAL I
+<Multi_key> <u> <h>			: "ʊ"	U028A		# LATIN SMALL LETTER UPSILON
+<Multi_key> <U> <H>			: "ʊ"	U028A		# LATIN SMALL LETTER UPSILON
+<Multi_key> <a> <h>			: "ɑ"	U0251		# LATIN SMALL LETTER ALPHA
+<Multi_key> <e> <r>			: "ɚ"	U025A		# LATIN SMALL LETTER SCHWA WITH HOOK
+<Multi_key> <o> <parenright>		:"ɔ" 	U0254 		# LATIN SMALL LETTER OPEN O
+<Multi_key> <a> <w>			: "ɔ"	U0254		# LATIN SMALL LETTER OPEN O
+<Multi_key> <O> <parenright>		:"Ɔ" 	U0186 		# LATIN CAPITAL LETTER OPEN O
+<Multi_key> <A> <W>			: "Ɔ"	U0186		# LATIN CAPITAL LETTER OPEN O
+<Multi_key> <e> <h>   	    	    	: "ɛ"   U025B		# LATIN SMALL LETTER OPEN E
+# Have to put the <less> at the beginning for these.
+<Multi_key> <less> <a> <h>		: "ɒ"	U0252		# LATIN SMALL LETTER TURNED ALPHA
+<Multi_key> <BackSpace> <a> <h>		: "ɒ"	U0252		# LATIN SMALL LETTER TURNED ALPHA
+<Multi_key> <less> <e> <h>		: "ɜ"	U025C		# LATIN SMALL LETTER REVERSED OPEN E
+<Multi_key> <BackSpace> <e> <h>		: "ɜ"	U025C		# LATIN SMALL LETTER REVERSED OPEN E
+<Multi_key> <less> <e> <r>		: "ɝ"	U025D		# LATIN SMALL LETTER REVERSED OPEN E WITH HOOK
+<Multi_key> <BackSpace> <e> <r>		: "ɝ"	U025D		# LATIN SMALL LETTER REVERSED OPEN E WITH HOOK
+# It's spelled "gy" in Hungarian...
+<Multi_key> <g> <y>			: "ɟ"	U025F		# LATIN SMALL LETTER DOTLESS J WITH STROKE
+# How are these keystrokes?
+<Multi_key> <bar> <apostrophe>		: "ˈ"	U02C8		# MODIFIER LETTER VERTICAL LINE
+<Multi_key> <bar> <comma>		: "ˌ"	U02CC		# MODIFIER LETTER LOW VERTICAL LINE
+<Multi_key> <bar> <underscore>		: "̩"	U0329		# COMBINING VERTICAL LINE BELOW
+# Harmonize with other combiners.
+<Multi_key> <backslash> <underscore> <bar>	: "̩"	U0329		# COMBINING VERTICAL LINE BELOW
+<Multi_key> <r> <r>                     : "ɹ"   U0279           # LATIN SMALL LETTER TURNED R: voiced alveolar approximant (American English (at least) R)
+<Multi_key> <r> <d>                     : "ɾ"   U027E           # LATIN SMALL LETTER R WITH FISHHOOK: voiced alveolar flap or tap (American English intervocalic allophone of d, or Spanish r)
+<Multi_key> <v> <v>                     : "ʌ"   U028C           # LATIN SMALL LETTER TURNED V
+<Multi_key> <u> <i>			: "ɯ"	U026F		# LATIN SMALL LETTER TURNED M
+# doubling a letter seems to be mostly used for turning
+<Multi_key> <w> <w>			: "ʍ"	U028D		# LATIN SMALL LETTER TURNED W
+<Multi_key> <y> <y>			: "ʎ"	U028E		# LATIN SMALL LETTER TURNED Y
+<Multi_key> <a> <a>			: "ɐ"	U0250		# LATIN SMALL LETTER TURNED A
+<Multi_key> <h> <h>			: "ɥ"	U0265		# LATIN SMALL LETTER TURNED H
+# ı is already available in the "standard" .XCompose
+<Multi_key> <j> <period>    		: "ȷ"	U0237		# LATIN SMALL LETTER DOTLESS J
+<Multi_key> <exclam> <period>		: "Ꞌ"	UA78B		# LATIN CAPITAL LETTER SALTILLO
+<Multi_key> <exclam> <underscore> <period>		: "ꞌ"	UA78C		# LATIN SMALL LETTER SALTILLO
+# I'll use capitals for a different double
+<Multi_key> <W> <W>			: "ʬ"	U02AC		# LATIN LETTER BILABIAL PERCUSSIVE
+# Also handy for writing urls: http://ʬw.omniglot.com/
+# Sorry, I miss having this and hate having to use colon instead:
+<Multi_key> <colon> <plus>  	      	: "ː"	U02D0		# MODIFIER LETTER TRIANGULAR COLON
+# ɣ? ᴥ?  Important enough to add? ᴥ is cool just as a "latin" letter.
+<Multi_key> <g> <h>	     	    : "ɣ"   U0263     # LATIN SMALL LETTER GAMMA
+# It looks like a ɣ and makes an "o" sorta sound:
+<Multi_key> <o> <g> <h>	      	    : "ɤ"  U0264      # LATIN SMALL LETTER RAMS HORN
+<Multi_key> <a> <i> <n>		    : "ᴥ"   U1D25     # LATIN LETTER AIN
+# Sometimes it's a "tail", sometimes a "hook", and sometimes a "retroflex hook"
+<Multi_key> <d> <comma>		    : "ɖ"   U0256     # LATIN SMALL LETTER D WITH TAIL
+<Multi_key> <l> <comma>		    : "ɭ"   U026D     # LATIN SMALL LETTER L WITH RETROFLEX HOOK
+<Multi_key> <n> <comma>		    : "ɳ"   U0273     # LATIN SMALL LETTER N WITH RETROFLEX HOOK
+<Multi_key> <s> <comma>		    : "ʂ"   U0282     # LATIN SMALL LETTER S WITH HOOK
+<Multi_key> <t> <comma>		    : "ʈ"   U0288     # LATIN SMALL LETTER T WITH RETROFLEX HOOK
+<Multi_key> <z> <comma>		    : "ʐ"   U0290     # LATIN SMALL LETTER Z WITH RETROFLEX HOOK
+# This is used for functions, folders, etc.  Yeah, the hook's facing wrong.
+<Multi_key> <f> <comma>		    : "ƒ"   U0192     # LATIN SMALL LETTER F WITH HOOK
+# Sigh, might as well do implosives.  Which is also sometimes a hook.
+<Multi_key> <b> <apostrophe>	    : "ɓ"   U0253     # LATIN SMALL LETTER B WITH HOOK
+<Multi_key> <d> <apostrophe>	    : "ɗ"   U0257     # LATIN SMALL LETTER D WITH HOOK
+<Multi_key> <g> <apostrophe>	    : "ɠ"   U0260     # LATIN SMALL LETTER G WITH HOOK
+<Multi_key> <g> <g>		    : "ɡ"   U0261     # LATIN SMALL LETTER SCRIPT G
+# The h looks the same...
+<Multi_key> <h> <apostrophe>	    : "ɦ"   U0266     # LATIN SMALL LETTER H WITH HOOK
+<Multi_key> <G> <apostrophe>	    : "ʛ"   U029B     # LATIN LETTER SMALL CAPITAL G WITH HOOK
+<Multi_key> <N> <o>			: "№"	U2116		# NUMERO SIGN
+<Multi_key> <R> <x>			: "℞"	U211E		# PRESCRIPTION TAKE
+<Multi_key> <P> <e> <r>			: "⅌"	U214C		# PER SIGN
+<Multi_key> <o> <z> <period>		: "℥"	U2125		# OUNCE SIGN
+<Multi_key> <s> <c> <r> <period>	: "℈"	U2108		# SCRUPLE
+# There are all kinds of awesome combining characters in the U+0300 page.
+# There are a bunch of other awesome combining characters like U+20E0
+<Multi_key> <asterisk> <period> <period> <period> : "๛" U0E5B   # THAI CHARACTER KHOMUT (end of chapter)
+#
+# Music stuff.  # is the music mnemonic.
+<Multi_key> <numbersign> <b>		: "♭" U266d # MUSIC FLAT SIGN
+<Multi_key> <numbersign> <f>		: "♮" U266e # MUSIC NATURAL SIGN
+<Multi_key> <numbersign> <equal>	: "♮" U266e # MUSIC NATURAL SIGN
+<Multi_key> <numbersign> <numbersign>	: "♯" U266f # MUSIC SHARP SIGN
+<Multi_key> <numbersign> <G>             : "𝄞"  U0001d11e # MUSICAL SYMBOL G CLEF
+<Multi_key> <numbersign> <F>              : "𝄢"  U0001d122 # MUSICAL SYMBOL F CLEF
+<Multi_key> <numbersign> <C>              : "𝄡" U0001d121 # MUSICAL SYMBOL C CLEF
+<Multi_key> <numbersign> <o> <slash>	: "♪" U266a	# EIGHTH NOTE
+<Multi_key> <numbersign> <o> <o>	: "♫" U266b	# BEAMED EIGHTH NOTES
+<Multi_key> <numbersign> <percent>	: "♫" U266b	# BEAMED EIGHTH NOTES
+<Multi_key> <numbersign> <q>            : "♩" U2669	# QUARTER NOTE
+<Multi_key> <numbersign> <h>            : "𝅗𝅥" U0001d15e	# MUSICAL SYMBOL HALF NOTE
+<Multi_key> <numbersign> <w>            : "𝅝" U0001d15d	# MUSICAL SYMBOL WHOLE NOTE
+
+
+# Combining accents, for making things you don't have precomposed chars or keystrokes for:
+<Multi_key> <backslash> <grave>	: "̀"  U0300   # COMBINING GRAVE ACCENT
+<Multi_key> <backslash> <apostrophe>    : "́"   U0301   # COMBINING ACUTE ACCENT
+<Multi_key> <backslash> <asciicircum>    : "̂"   U0302   # COMBINING CIRCUMFLEX ACCENT
+<Multi_key> <backslash> <asciitilde>       : "̃"   U0303	# COMBINING TILDE
+<Multi_key> <backslash> <equal>		: "̄"	U0304	# COMBINING MACRON
+<Multi_key> <backslash> <backslash> <equal>		: "̅"	U0305	# COMBINING OVERLINE -- ???
+<Multi_key> <backslash> <U>		: "̆"	U0306	# COMBINING BREVE
+<Multi_key> <backslash> <period>	: "̇"	U0307	# COMBINING DOT ABOVE
+<Multi_key> <backslash> <quotedbl>	: "̈"	U0308	# COMBINING DIAERESIS
+<Multi_key> <backslash> <question>	: "̉"	U0309	# COMBINING HOOK ABOVE
+<Multi_key> <backslash> <o>		: "̊"	U030a	# COMBINING RING ABOVE
+# That now conflicts with the new 🙌 in the system xcompose.  Alternative:
+<Multi_key> <backslash> <0>   	       	: "̊"	U030a	# COMBINING RING ABOVE
+<Multi_key> <backslash> <backslash> <apostrophe>	: "̋"	U030b	# COMBINING DOUBLE ACUTE ACCENT -- ??
+<Multi_key> <backslash> <c>		: "̌"	U030c	# COMBINING CARON
+<Multi_key> <backslash> <bar>       	: "̍"	U030d	# COMBINING VERTICAL LINE ABOVE
+<Multi_key> <backslash> <2> <bar>	: "̎"	U030e	# COMBINING DOUBLE VERTICAL LINE ABOVE
+<Multi_key> <backslash> <2> <grave>	: "̏"	U030f	# COMBINING DOUBLE GRAVE ACCENT
+# For writing PSILI and DASIA in Greek
+# Ugh, better key-coding?  I may need @ for BELOW.
+<Multi_key> <backslash> <backslash> <backslash> <comma>	:	"̒"  U0312   # COMBINING TURNED COMMA ABOVE
+<Multi_key> <backslash> <backslash> <comma>	:	"̓"  U0313   # COMBINING COMMA ABOVE
+<Multi_key> <backslash> <backslash> <less> <comma>	:	"̔"   U0314   # COMBINING REVERSED COMMA ABOVE
+<Multi_key> <backslash> <f> <m>                 : "͒"   U0352   # COMBINING FERMATA
+<Multi_key> <backslash> <parenleft> <period>	: "̐"	U0310	# COMBINING CHANDRABINDU
+<Multi_key> <backslash> <i> <b>		: "̑"	U0311	# COMBINING INVERTED BREVE -- ??
+<Multi_key> <backslash> <parenleft> <parenright>: "⃝"  U20DD # COMBINING ENCLOSING CIRCLE
+<Multi_key> <backslash> <bracketleft> <q> <bracketright>:    "⃞"  U20DE     # COMBINING ENCLOSING SQUARE
+<Multi_key> <backslash> <bracketleft> <d> <bracketright>:    "⃟"  U20DF     # COMBINING ENCLOSING DIAMOND
+<Multi_key> <backslash> <parenleft> <slash> <parenright>:    "⃠"	 U20E0	   # COMBINING ENCLOSING CIRCLE BACKSLASH
+<Multi_key> <backslash> <bracketleft> <s> <bracketright>:    "⃢"  U20E2     # COMBINING ENCLOSING SCREEN
+<Multi_key> <backslash> <bracketleft> <k> <bracketright>:    "⃣"  U20E3     # COMBINING ENCLOSING KEYCAP
+<Multi_key> <backslash> <bracketleft> <t> <bracketright>:    "⃤"  U20E4     # COMBINING ENCLOSING TRIANGLE
+<Multi_key> <backslash> <2> <slash>:  "⃫"  U20EB              # COMBINING LONG DOUBLE SOLIDUS OVERLAY
+<Multi_key> <backslash> <asterisk>:   "⃰"  U20F0     # COMBINING ASTERISK ABOVE
+<Multi_key> <backslash> <exclam>	: "̣"   U0323   # COMBINING DOT BELOW
+# With only one underscore it conflicts with stuff.
+<Multi_key> <backslash> <underscore> <underscore>	: "̱"	U0331	# COMBINING MACRON BELOW
+<Multi_key> <backslash> <backslash> <underscore>	: "̲"	U0332	# COMBINING LOW LINE
+<Multi_key> <backslash> <backslash> <backslash> <underscore>	: "̳"	U0333	# COMBINING DOUBLE LOW LINE
+
+# The @ sign will signify reversal to the bottom of the glyph, 'kay?
+
+<Multi_key> <backslash> <at> <o>	: "̥"	U0325	# COMBINING RING BELOW
+
+<Multi_key> <backslash> <at> <c>	: "̬"	U032c	# COMBINING CARON BELOW
+<Multi_key> <backslash> <at> <asciicircum>	: "̭"	U032d	# COMBINING CIRCUMFLEX ACCENT BELOW
+<Multi_key> <backslash> <at> <U>	: "̮"	U032e	# COMBINING BREVE BELOW
+<Multi_key> <backslash> <at> <i> <b>	: "̯"	U032f	# COMBINING INVERTED BREVE BELOW -- ??
+
+# How about leading & (or &&?) for double combiners?  There aren't many anyway.
+# Except that I found myself assuming it was "2" for double.
+<Multi_key> <backslash> <ampersand> <at> <U> : "͜" U035C # COMBINING DOUBLE BREVE BELOW
+<Multi_key> <backslash> <2> <at> <U> : "͜" U035C # COMBINING DOUBLE BREVE BELOW
+<Multi_key> <backslash> <ampersand> <U>	  : "͝"	U035D   # COMBINING DOUBLE BREVE
+<Multi_key> <backslash> <2> <U>	  : "͝"	U035D   # COMBINING DOUBLE BREVE
+<Multi_key> <backslash> <ampersand> <minus> : "͞" U035E	# COMBINING DOUBLE MACRON
+<Multi_key> <backslash> <2> <minus> : "͞" U035E	# COMBINING DOUBLE MACRON
+<Multi_key> <backslash> <ampersand> <at> <minus> : "͟" U035F # COMBINING DOUBLE MACRON BELOW
+<Multi_key> <backslash> <2> <at> <minus> : "͟" U035F # COMBINING DOUBLE MACRON BELOW
+<Multi_key> <backslash> <ampersand> <underscore> : "͟" U035F # COMBINING DOUBLE MACRON BELOW
+<Multi_key> <backslash> <2> <underscore> : "͟" U035F # COMBINING DOUBLE MACRON BELOW
+<Multi_key> <backslash> <ampersand> <asciitilde> : "͠" U0360 # COMBINING DOUBLE TILDE
+<Multi_key> <backslash> <2> <asciitilde> : "͠" U0360 # COMBINING DOUBLE TILDE
+<Multi_key> <backslash> <ampersand> <i> <b>  : "͡"  U0361 # COMBINING DOUBLE INVERTED BREVE
+<Multi_key> <backslash> <2> <i> <b>  : "͡"  U0361 # COMBINING DOUBLE INVERTED BREVE
+<Multi_key> <backslash> <ampersand> <at> <i> <b>  : "᷼"  U1DFC # COMBINING DOUBLE INVERTED BREVE BELOW
+<Multi_key> <backslash> <2> <at> <i> <b>  : "᷼"  U1DFC # COMBINING DOUBLE INVERTED BREVE BELOW
+# Might as well finish up the set.
+<Multi_key> <backslash> <ampersand> <greater> : "͢" U0362 # COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+<Multi_key> <backslash> <2> <greater> : "͢" U0362 # COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+
+<Multi_key> <period> <parenright>	: "͒"	U0352   # COMBINING FERMATA
+
+<Multi_key> <backslash> <backslash> <asterisk>	: "҉"	U0489	# COMBINING CYRILLIC MILLIONS SIGN  -- aka COMBINING SHINY
+<Multi_key> <P> <minus>		: "₽"	U20BD	# RUBLE SIGN
+<Multi_key> <p> <minus>		: "₽"	U20BD	# RUBLE SIGN
+
+# How about for a little extra control:
+<Multi_key> <Z> <W> <S> <P>		: "​"	U200B	# ZERO WIDTH SPACE
+<Multi_key> <Z> <W> <N> <J>		: "‌"	U200C	# ZERO WIDTH NON-JOINER
+<Multi_key> <Z> <W> <J>			: "‍"	U200D	# ZERO WIDTH JOINER
+<Multi_key> <L> <R> <M>			: "‎"	U200E	# LEFT-TO-RIGHT MARK
+<Multi_key> <R> <L> <M>			: "‏"	U200F	# RIGHT-TO-LEFT MARK
+# I never understood the whole embedding/pop thing, but we might as well add 'em
+<Multi_key> <L> <R> <E>			: "‪"	U202A	# LEFT-TO-RIGHT EMBEDDING
+<Multi_key> <R> <L> <E>			: "‫"	U202B	# RIGHT-TO-LEFT EMBEDDING
+<Multi_key> <P> <D> <F>			: "‬"	U202C	# POP DIRECTIONAL FORMATTING
+<Multi_key> <L> <R> <I>			: "⁦"	U2066	# LEFT-TO-RIGHT ISOLATE
+<Multi_key> <R> <L> <I>			: "⁧"	U2067	# RIGHT-TO-LEFT ISOLATE
+<Multi_key> <F> <S> <I>			: "⁨"	U2068	# FIRST STRONG ISOLATE
+<Multi_key> <P> <D> <I>			: "⁩"	U2069	# POP DIRECTIONAL ISOLATE
+<Multi_key> <L> <R> <O>			: "‭"	U202D	# LEFT-TO-RIGHT OVERRIDE
+<Multi_key> <R> <L> <O>			: "‮"	U202E	# RIGHT-TO-LEFT OVERRIDE
+<Multi_key> <B> <O> <M>			: "﻿"	UFEFF	# ZERO WIDTH NO-BREAK SPACE (Byte Order Mark)
+<Multi_key> <C> <G> <J>			: "͏"	U034F	# COMBINING GRAPHEME JOINER
+<Multi_key> <W> <J>                     : "⁠"    U2060   # WORD JOINER
+# These are sufficiently special and well-known that they don't need the
+# double <Multi_key> prefix I think.  The all-caps helps too.
+
+# How about some small-caps?  We normally use a special character as a prefix,
+# but why not a suffix?  It won't interfere with things that way.
+# Several of these are also IPA, which is handy.  And so a few have multiple
+# entries.  Whatever.
+
+<Multi_key> <a> <grave>	    	  : "ᴀ"	    U1D00 # LATIN LETTER SMALL CAPITAL A
+<Multi_key> <b> <grave>	    	  : "ʙ"	    U0299 # LATIN LETTER SMALL CAPITAL B
+<Multi_key> <c> <grave>	    	  : "ᴄ"	    U1D04 # LATIN LETTER SMALL CAPITAL C
+<Multi_key> <d> <grave>	    	  : "ᴅ"	    U1D05 # LATIN LETTER SMALL CAPITAL D
+<Multi_key> <e> <grave>	    	  : "ᴇ"	    U1D07 # LATIN LETTER SMALL CAPITAL E
+<Multi_key> <f> <grave>	    	  : "ꜰ"	    UA730 # LATIN LETTER SMALL CAPITAL F
+<Multi_key> <g> <grave>	    	  : "ɢ"	    U0262 # LATIN LETTER SMALL CAPITAL G
+<Multi_key> <h> <grave>	    	  : "ʜ"	    U029C # LATIN LETTER SMALL CAPITAL H
+<Multi_key> <i> <grave>	    	  : "ɪ"	    U026A # LATIN LETTER SMALL CAPITAL I
+<Multi_key> <j> <grave>	    	  : "ᴊ"	    U1D0A # LATIN LETTER SMALL CAPITAL J
+<Multi_key> <k> <grave>	    	  : "ᴋ"	    U1D0B # LATIN LETTER SMALL CAPITAL K
+<Multi_key> <l> <grave>	    	  : "ʟ"	    U029F # LATIN LETTER SMALL CAPITAL L
+<Multi_key> <m> <grave>	    	  : "ᴍ"	    U1D0D # LATIN LETTER SMALL CAPITAL M
+<Multi_key> <n> <grave>	    	  : "ɴ"	    U0274 # LATIN LETTER SMALL CAPITAL N
+<Multi_key> <o> <grave>	    	  : "ᴏ"	    U1D0F # LATIN LETTER SMALL CAPITAL O
+<Multi_key> <p> <grave>	    	  : "ᴘ"	    U1D18 # LATIN LETTER SMALL CAPITAL P
+<Multi_key> <q> <grave>	    	  : "ꞯ"	    UA7AF # LATIN LETTER SMALL CAPITAL Q
+<Multi_key> <r> <grave>	    	  : "ʀ"	    U0280 # LATIN LETTER SMALL CAPITAL R
+<Multi_key> <s> <grave>	    	  : "ꜱ"	    UA731 # LATIN LETTER SMALL CAPITAL S
+<Multi_key> <t> <grave>	    	  : "ᴛ"	    U1D1B # LATIN LETTER SMALL CAPITAL T
+<Multi_key> <u> <grave>	    	  : "ᴜ"	    U1D1C # LATIN LETTER SMALL CAPITAL U
+<Multi_key> <v> <grave>	    	  : "ᴠ"	    U1D20 # LATIN LETTER SMALL CAPITAL V
+<Multi_key> <w> <grave>	    	  : "ᴡ"	    U1D21 # LATIN LETTER SMALL CAPITAL W
+# There is no SMALL CAPITAL X (yet)
+<Multi_key> <y> <grave>	    	  : "ʏ"	    U028F # LATIN LETTER SMALL CAPITAL Y
+<Multi_key> <z> <grave>	    	  : "ᴢ"	    U1D22 # LATIN LETTER SMALL CAPITAL Z
+
+
+# See also http://bleah.co.uk/~simon/stuff/XCompose
+# and http://dotfiles.org/~inky/.XCompose
+# and http://paste.lisp.org/display/73094
+
+<Multi_key> <Multi_key> <s> <u> <n>	: "☉"	U2609	# SUN (Sunday)
+<Multi_key> <Multi_key> <m> <o> <o> <n>	: "☽"	U263D	# FIRST QUARTER MOON (Monday)
+<Multi_key> <Multi_key> <m> <e> <r> <c> <u> <r> <y> : "☿" U263F	# MERCURY (Wednesday)
+# We already have Venus (Friday) and Mars (Tuesday) as Male/Female signs; do we need them here too?
+#<Multi_key> <Multi_key> <v> <e> <n> <u> <s>  : "♀" U2640    # FEMALE SIGN
+#<Multi_key> <Multi_key> <m> <a> <r> <s>  : "♂"	U2642   # MALE SIGN
+<Multi_key> <Multi_key> <j> <u> <p> <i> <t> <e> <r> : "♃" U2643	# JUPITER (Thursday)
+<Multi_key> <Multi_key> <s> <a> <t> <u> <r> <n>     : "♄" U2644	# SATURN (Saturday)
+<Multi_key> <Multi_key> <u> <r> <a> <n> <u> <s>	    : "♅" U2645	# URANUS (or ⛢ U26E2?)
+<Multi_key> <Multi_key> <n> <e> <p> <t> <u> <n> <e> : "♆" U2646	# NEPTUNE
+<Multi_key> <Multi_key> <p> <l> <u> <t> <o> 	    : "♇" U2647	# PLUTO (ok, it isn't a planet anymore, but we still love it.)
+# Minor planets, whilst we're at it?
+<Multi_key> <Multi_key> <c> <e> <r> <e> <s>	: "⚳"	U26B3	# CERES
+<Multi_key> <Multi_key> <p> <a> <l> <l> <a> <s>	: "⚴"	U26B4	# PALLAS
+<Multi_key> <Multi_key> <j> <u> <n> <o>     	: "⚵"	U26B5	# JUNO
+<Multi_key> <Multi_key> <v> <e> <s> <t> <a>    	: "⚶"	U26B6	# VESTA
+<Multi_key> <Multi_key> <c> <h> <i> <r> <o> <n>	: "⚷"	U26B7	# CHIRON
+<Multi_key> <Multi_key> <l> <i> <l> <i> <t> <h>	: "⚸"	U26B8	# BLACK MOON LILITH
+<Multi_key>  <bracketleft> <k> <e> <y> <bracketright> : "⚿"	U26BF	# SQUARED KEY
+
+# Unicode 6.0 gave us all kinds of things, perhaps more than we can use...
+
+# Playing Cards?  It's a lot, but so what?  I don't think the [] convention
+# will conflict with anything.
+# The convention is more or less established, except for the Knight.  I'm
+# using N for that, like in Chess, since K would conflict with King of course.
+
+<Multi_key> <bracketleft> <A> <S> <bracketright>  : "🂡"	U1F0A1	# PLAYING CARD ACE OF SPADES
+<Multi_key> <bracketleft> <2> <S> <bracketright>  : "🂢"	U1F0A2	# PLAYING CARD TWO OF SPADES
+<Multi_key> <bracketleft> <3> <S> <bracketright>  : "🂣"	U1F0A3	# PLAYING CARD THREE OF SPADES
+<Multi_key> <bracketleft> <4> <S> <bracketright>  : "🂤"	U1F0A4	# PLAYING CARD FOUR OF SPADES
+<Multi_key> <bracketleft> <5> <S> <bracketright>  : "🂥"	U1F0A5	# PLAYING CARD FIVE OF SPADES
+<Multi_key> <bracketleft> <6> <S> <bracketright>  : "🂦"	U1F0A6	# PLAYING CARD SIX OF SPADES
+<Multi_key> <bracketleft> <7> <S> <bracketright>  : "🂧"	U1F0A7	# PLAYING CARD SEVEN OF SPADES
+<Multi_key> <bracketleft> <8> <S> <bracketright>  : "🂨"	U1F0A8	# PLAYING CARD EIGHT OF SPADES
+<Multi_key> <bracketleft> <9> <S> <bracketright>  : "🂩"	U1F0A9	# PLAYING CARD NINE OF SPADES
+<Multi_key> <bracketleft> <T> <S> <bracketright>  : "🂪"	U1F0AA	# PLAYING CARD TEN OF SPADES
+<Multi_key> <bracketleft> <J> <S> <bracketright>  : "🂫"	U1F0AB	# PLAYING CARD JACK OF SPADES
+<Multi_key> <bracketleft> <N> <S> <bracketright>  : "🂬"	U1F0AC	# PLAYING CARD KNIGHT OF SPADES
+<Multi_key> <bracketleft> <Q> <S> <bracketright>  : "🂭"	U1F0AD	# PLAYING CARD QUEEN OF SPADES
+<Multi_key> <bracketleft> <K> <S> <bracketright>  : "🂮"	U1F0AE	# PLAYING CARD KING OF SPADES
+
+<Multi_key> <bracketleft> <A> <H> <bracketright>  : "🂱"	U1F0B1	# PLAYING CARD ACE OF HEARTS
+<Multi_key> <bracketleft> <2> <H> <bracketright>  : "🂲"	U1F0B2	# PLAYING CARD TWO OF HEARTS
+<Multi_key> <bracketleft> <3> <H> <bracketright>  : "🂳"	U1F0B3	# PLAYING CARD THREE OF HEARTS
+<Multi_key> <bracketleft> <4> <H> <bracketright>  : "🂴"	U1F0B4	# PLAYING CARD FOUR OF HEARTS
+<Multi_key> <bracketleft> <5> <H> <bracketright>  : "🂵"	U1F0B5	# PLAYING CARD FIVE OF HEARTS
+<Multi_key> <bracketleft> <6> <H> <bracketright>  : "🂶"	U1F0B6	# PLAYING CARD SIX OF HEARTS
+<Multi_key> <bracketleft> <7> <H> <bracketright>  : "🂷"	U1F0B7	# PLAYING CARD SEVEN OF HEARTS
+<Multi_key> <bracketleft> <8> <H> <bracketright>  : "🂸"	U1F0B8	# PLAYING CARD EIGHT OF HEARTS
+<Multi_key> <bracketleft> <9> <H> <bracketright>  : "🂹"	U1F0B9	# PLAYING CARD NINE OF HEARTS
+<Multi_key> <bracketleft> <T> <H> <bracketright>  : "🂺"	U1F0BA	# PLAYING CARD TEN OF HEARTS
+<Multi_key> <bracketleft> <J> <H> <bracketright>  : "🂻"	U1F0BB	# PLAYING CARD JACK OF HEARTS
+<Multi_key> <bracketleft> <N> <H> <bracketright>  : "🂼"	U1F0BC	# PLAYING CARD KNIGHT OF HEARTS
+<Multi_key> <bracketleft> <Q> <H> <bracketright>  : "🂽"	U1F0BD	# PLAYING CARD QUEEN OF HEARTS
+<Multi_key> <bracketleft> <K> <H> <bracketright>  : "🂾"	U1F0BE	# PLAYING CARD KING OF HEARTS
+
+<Multi_key> <bracketleft> <A> <D> <bracketright>  : "🃁"	U1F0C1	# PLAYING CARD ACE OF DIAMONDS
+<Multi_key> <bracketleft> <2> <D> <bracketright>  : "🃂"	U1F0C2	# PLAYING CARD TWO OF DIAMONDS
+<Multi_key> <bracketleft> <3> <D> <bracketright>  : "🃃"	U1F0C3	# PLAYING CARD THREE OF DIAMONDS
+<Multi_key> <bracketleft> <4> <D> <bracketright>  : "🃄"	U1F0C4	# PLAYING CARD FOUR OF DIAMONDS
+<Multi_key> <bracketleft> <5> <D> <bracketright>  : "🃅"	U1F0C5	# PLAYING CARD FIVE OF DIAMONDS
+<Multi_key> <bracketleft> <6> <D> <bracketright>  : "🃆"	U1F0C6	# PLAYING CARD SIX OF DIAMONDS
+<Multi_key> <bracketleft> <7> <D> <bracketright>  : "🃇"	U1F0C7	# PLAYING CARD SEVEN OF DIAMONDS
+<Multi_key> <bracketleft> <8> <D> <bracketright>  : "🃈"	U1F0C8	# PLAYING CARD EIGHT OF DIAMONDS
+<Multi_key> <bracketleft> <9> <D> <bracketright>  : "🃉"	U1F0C9	# PLAYING CARD NINE OF DIAMONDS
+<Multi_key> <bracketleft> <T> <D> <bracketright>  : "🃊"	U1F0CA	# PLAYING CARD TEN OF DIAMONDS
+<Multi_key> <bracketleft> <J> <D> <bracketright>  : "🃋"	U1F0CB	# PLAYING CARD JACK OF DIAMONDS
+<Multi_key> <bracketleft> <N> <D> <bracketright>  : "🃌"	U1F0CC	# PLAYING CARD KNIGHT OF DIAMONDS
+<Multi_key> <bracketleft> <Q> <D> <bracketright>  : "🃍"	U1F0CD	# PLAYING CARD QUEEN OF DIAMONDS
+<Multi_key> <bracketleft> <K> <D> <bracketright>  : "🃎"	U1F0CE	# PLAYING CARD KING OF DIAMONDS
+
+<Multi_key> <bracketleft> <A> <C> <bracketright>  : "🃑"	U1F0D1	# PLAYING CARD ACE OF CLUBS
+<Multi_key> <bracketleft> <2> <C> <bracketright>  : "🃒"	U1F0D2	# PLAYING CARD TWO OF CLUBS
+<Multi_key> <bracketleft> <3> <C> <bracketright>  : "🃓"	U1F0D3	# PLAYING CARD THREE OF CLUBS
+<Multi_key> <bracketleft> <4> <C> <bracketright>  : "🃔"	U1F0D4	# PLAYING CARD FOUR OF CLUBS
+<Multi_key> <bracketleft> <5> <C> <bracketright>  : "🃕"	U1F0D5	# PLAYING CARD FIVE OF CLUBS
+<Multi_key> <bracketleft> <6> <C> <bracketright>  : "🃖"	U1F0D6	# PLAYING CARD SIX OF CLUBS
+<Multi_key> <bracketleft> <7> <C> <bracketright>  : "🃗"	U1F0D7	# PLAYING CARD SEVEN OF CLUBS
+<Multi_key> <bracketleft> <8> <C> <bracketright>  : "🃘"	U1F0D8	# PLAYING CARD EIGHT OF CLUBS
+<Multi_key> <bracketleft> <9> <C> <bracketright>  : "🃙"	U1F0D9	# PLAYING CARD NINE OF CLUBS
+<Multi_key> <bracketleft> <T> <C> <bracketright>  : "🃚"	U1F0DA	# PLAYING CARD TEN OF CLUBS
+<Multi_key> <bracketleft> <J> <C> <bracketright>  : "🃛"	U1F0DB	# PLAYING CARD JACK OF CLUBS
+<Multi_key> <bracketleft> <N> <C> <bracketright>  : "🃜"	U1F0DC	# PLAYING CARD KNIGHT OF CLUBS
+<Multi_key> <bracketleft> <Q> <C> <bracketright>  : "🃝"	U1F0DD	# PLAYING CARD QUEEN OF CLUBS
+<Multi_key> <bracketleft> <K> <C> <bracketright>  : "🃞"	U1F0DE	# PLAYING CARD KING OF CLUBS
+
+<Multi_key> <bracketleft> <C> <B> <bracketright>  : "🂠"	U1F0A0	# PLAYING CARD BACK
+<Multi_key> <bracketleft> <B> <J> <bracketright>  : "🃏" U1F0CF	# PLAYING CARD BLACK JOKER
+<Multi_key> <bracketleft> <W> <J> <bracketright>  : "🃟"	U1F0DF	# PLAYING CARD WHITE JOKER
+
+# Do we want domino bones also?  I'm thinking [ 1 1 ], etc, maybe use
+# ] 1 1 [ for vertical (or vice-versa)
+
+# And chess/checkers pieces! We need a convention for those.  # looks like a
+# checkerboard but we're already using that for music.  Half of it?
+# <bar> will be an issue when we want double-struck W or B... we'll have
+# to consider it.  Maybe replace with <equal>
+<Multi_key> <bar> <W> <K>	 : "♔" U2654	# WHITE CHESS KING
+<Multi_key> <bar> <W> <Q>	 : "♕" U2655	# WHITE CHESS QUEEN
+<Multi_key> <bar> <W> <R>	 : "♖" U2656	# WHITE CHESS ROOK
+<Multi_key> <bar> <W> <B>	 : "♗" U2657	# WHITE CHESS BISHOP
+<Multi_key> <bar> <W> <N>	 : "♘" U2658	# WHITE CHESS KNIGHT
+<Multi_key> <bar> <W> <P>	 : "♙" U2659	# WHITE CHESS PAWN
+<Multi_key> <bar> <B> <K>	 : "♚" U265A	# BLACK CHESS KING
+<Multi_key> <bar> <B> <Q>	 : "♛" U265B	# BLACK CHESS QUEEN
+<Multi_key> <bar> <B> <R>	 : "♜" U265C	# BLACK CHESS ROOK
+<Multi_key> <bar> <B> <B>	 : "♝" U265D	# BLACK CHESS BISHOP
+<Multi_key> <bar> <B> <N>	 : "♞" U265E	# BLACK CHESS KNIGHT
+<Multi_key> <bar> <B> <P>	 : "♟" U265F	# BLACK CHESS PAWN
+<Multi_key> <bar> <W> <D> <M>	 : "⛀" U26C0	# WHITE DRAUGHTS MAN
+<Multi_key> <bar> <W> <D> <K>	 : "⛁" U26C1	# WHITE DRAUGHTS KING
+<Multi_key> <bar> <B> <D> <M>	 : "⛂" U26C2	# BLACK DRAUGHTS MAN
+<Multi_key> <bar> <B> <D> <K>	 : "⛃" U26C3	# BLACK DRAUGHTS KING
+# Since we're doing game pieces, might as well.
+<Multi_key> <bar> <W> <S>	 : "☖" U2616	# WHITE SHOGI PIECE
+<Multi_key> <bar> <B> <S>	 : "☗" U2617	# BLACK SHOGI PIECE
+# It's turned vertically and not horizontally reflected, but we use the <
+# symbol for turning...
+<Multi_key> <bar> <less> <W> <S> : "⛉" U26C9	# TURNED WHITE SHOGI PIECE
+<Multi_key> <bar> <less> <B> <S> : "⛊" U26CA	# TURNED BLACK SHOGI PIECE
+
+# As for the emoji... We can't possibly get all of them, even just all of the
+# cool/useful ones.  Maybe we can pick and choose some high-fliers.
+
+<Multi_key> <Multi_key> <d> <e> <g> <r> <e> <e> 		: "°"	U00B0	# DEGREE SIGN
+<Multi_key> <Multi_key> <d> <e> <g> <C> 		: "℃"   U2103 	# DEGREE CELSIUS
+<Multi_key> <Multi_key> <d> <e> <g> <c> 		: "℃"   U2103 	# DEGREE CELSIUS
+<Multi_key> <Multi_key> <d> <e> <g> <F> 		: "℉"   U2109   # DEGREE FAHRENHEIT
+<Multi_key> <Multi_key> <d> <e> <g> <f> 		: "℉"   U2109   # DEGREE FAHRENHEIT
+
+# Zodiacal symbols?
+<Multi_key> <Multi_key> <a> <r> <i> <e> <s>	: "♈"	U2648	# ARIES
+<Multi_key> <Multi_key> <t> <a> <u> <r> <u> <s>	: "♉"	U2649	# TAURUS
+<Multi_key> <Multi_key> <g> <e> <m> <i> <n> <i>	: "♊"	U264A	# GEMINI
+<Multi_key> <Multi_key> <c> <a> <n> <c> <e> <r>	: "♋"	U264B	# CANCER
+<Multi_key> <Multi_key> <l> <e> <o> 		: "♌"	U264C	# LEO
+<Multi_key> <Multi_key> <v> <i> <r> <g> <o>	: "♍"	U264D	# VIRGO
+<Multi_key> <Multi_key> <l> <i> <b> <r> <a>	: "♎"	U264E	# LIBRA
+# Abbreviating some of the longer ones.
+<Multi_key> <Multi_key> <s> <c> <o> <r> <p>	: "♏"	U264F	# SCORPIUS
+<Multi_key> <Multi_key> <s> <a> <g> <i> <t>	: "♐"	U2650	# SAGITTARIUS
+<Multi_key> <Multi_key> <c> <a> <p> <r> <i> <c>	: "♑"	U2651	# CAPRICORN
+<Multi_key> <Multi_key> <a> <q> <u> <a> <r>	: "♒"	U2652	# AQUARIUS
+<Multi_key> <Multi_key> <p> <i> <s> <c> <e> <s>	: "♓"	U2653	# PISCES
+# Really, this should be SERPENTARIUS.  All the other signs are in Latin.
+<Multi_key> <Multi_key> <o> <p> <h> <i> <u> <c> : "⛎"	U26CE	# OPHIUCHUS
+
+# Sigh.  So many emoji...  I think the first ones I'd go for would be
+# 💡💢💣💤💥💦💧💨💫 (1F4A1-1F4A8 and 1F4AB).  Maybe 1F550-1F567 are useful.  
+<Multi_key> <Multi_key> <i> <d> <e> <a>	    : "💡"    U1F4A1 # ELECTRIC LIGHT BULB
+<Multi_key> <Multi_key> <a> <n> <g> <e> <r> : "💢"    U1F4A2 # ANGER SYMBOL
+<Multi_key> <Multi_key> <b> <o> <m> <b>	    : "💣"    U1F4A3 # BOMB
+<Multi_key> <Multi_key> <z> <z> <z> 	    : "💤"    U1F4A4 # SLEEPING SYMBOL
+<Multi_key> <Multi_key> <p> <o> <w>	    : "💥"    U1F4A5 # COLLISION SYMBOL
+<Multi_key> <Multi_key> <s> <w> <e> <a> <t> : "💦"    U1F4A6 # SPLASHING SWEAT SYMBOL
+<Multi_key> <Multi_key> <d> <r> <o> <p>	    : "💧"    U1F4A7 # DROPLET
+<Multi_key> <Multi_key> <z> <i> <p> 	    : "💨"    U1F4A8 # DASH SYMBOL
+<Multi_key> <Multi_key> <p> <o> <o>	    : "💩"    U1F4A9 # PILE OF POO
+# Skipping U+1F4AA just now.
+<Multi_key> <Multi_key> <d> <i> <z> <z> <y> : "💫"    U1F4AB # DIZZY SYMBOL
+<Multi_key> <Multi_key> <dollar> <b> <a> <g>  : "💰"  U1F4B0 # MONEY BAG
+<Multi_key> <Multi_key> <c> <a> <k> <e>	    : "🍰"    U1F370 # SHORTCAKE
+# The cake is a lie... OK, too cutesy?
+<Multi_key> <Multi_key> <l> <i> <e> 	    : "🎂"    U1F382 # BIRTHDAY CAKE
+<Multi_key> <Multi_key> <b> <d> <a> <y>	    : "🎂"    U1F382 # BIRTHDAY CAKE
+<Multi_key> <Multi_key> <A> <O> <K>	    : "👌"    U1F44C # OK HAND SIGN
+<Multi_key> <Multi_key> <t> <h> <m> <u> <p> : "👍"    U1F44D # THUMBS UP SIGN
+<Multi_key> <Multi_key> <t> <h> <m> <d> <n> : "👎"    U1F44E # THUMBS DOWN SIGN
+# More useful in chat than U+1F48F KISS
+<Multi_key> <Multi_key> <k> <i> <s> <s>	    : "💋"    U1F48B # KISS MARK
+<Multi_key> <Multi_key> <D> <N> <E>         : "⛔"    U26D4  # NO ENTRY
+# So many hearts... I'm not touching them for now.
+# And emoticons? (U+1F600 et seq) -- Moved to their own file.
+
+<Multi_key> <parenleft> <1> <colon> <0> <0> <parenright> : "🕐" U1F550 # CLOCK FACE ONE OCLOCK
+<Multi_key> <parenleft> <2> <colon> <0> <0> <parenright> : "🕑" U1F551 # CLOCK FACE TWO OCLOCK
+<Multi_key> <parenleft> <3> <colon> <0> <0> <parenright> : "🕒" U1F552 # CLOCK FACE THREE OCLOCK
+<Multi_key> <parenleft> <4> <colon> <0> <0> <parenright> : "🕓" U1F553 # CLOCK FACE FOUR OCLOCK
+<Multi_key> <parenleft> <5> <colon> <0> <0> <parenright> : "🕔" U1F554 # CLOCK FACE FIVE OCLOCK
+<Multi_key> <parenleft> <6> <colon> <0> <0> <parenright> : "🕕" U1F555 # CLOCK FACE SIX OCLOCK
+<Multi_key> <parenleft> <7> <colon> <0> <0> <parenright> : "🕖" U1F556 # CLOCK FACE SEVEN OCLOCK
+<Multi_key> <parenleft> <8> <colon> <0> <0> <parenright> : "🕗" U1F557 # CLOCK FACE EIGHT OCLOCK
+<Multi_key> <parenleft> <9> <colon> <0> <0> <parenright> : "🕘" U1F558 # CLOCK FACE NINE OCLOCK
+<Multi_key> <parenleft> <1> <0> <colon> <0> <0> <parenright> : "🕙" U1F559 # CLOCK FACE TEN OCLOCK
+<Multi_key> <parenleft> <1> <1> <colon> <0> <0> <parenright> : "🕚" U1F55A # CLOCK FACE ELEVEN OCLOCK
+<Multi_key> <parenleft> <1> <2> <colon> <0> <0> <parenright> : "🕛" U1F55B # CLOCK FACE TWELVE OCLOCK
+
+<Multi_key> <parenleft> <1> <colon> <3> <0> <parenright>     : "🕜" U1F55C # CLOCK FACE ONE-THIRTY
+<Multi_key> <parenleft> <2> <colon> <3> <0> <parenright>     : "🕝" U1F55D # CLOCK FACE TWO-THIRTY
+<Multi_key> <parenleft> <3> <colon> <3> <0> <parenright>     : "🕞" U1F55E # CLOCK FACE THREE-THIRTY
+<Multi_key> <parenleft> <4> <colon> <3> <0> <parenright>     : "🕟" U1F55F # CLOCK FACE FOUR-THIRTY
+<Multi_key> <parenleft> <5> <colon> <3> <0> <parenright>     : "🕠" U1F560 # CLOCK FACE FIVE-THIRTY
+<Multi_key> <parenleft> <6> <colon> <3> <0> <parenright>     : "🕡" U1F561 # CLOCK FACE SIX-THIRTY
+<Multi_key> <parenleft> <7> <colon> <3> <0> <parenright>     : "🕢" U1F562 # CLOCK FACE SEVEN-THIRTY
+<Multi_key> <parenleft> <8> <colon> <3> <0> <parenright>     : "🕣" U1F563 # CLOCK FACE EIGHT-THIRTY
+<Multi_key> <parenleft> <9> <colon> <3> <0> <parenright>     : "🕤" U1F564 # CLOCK FACE NINE-THIRTY
+<Multi_key> <parenleft> <1> <0> <colon> <3> <0> <parenright>     : "🕥" U1F565 # CLOCK FACE TEN-THIRTY
+<Multi_key> <parenleft> <1> <1> <colon> <3> <0> <parenright>     : "🕦" U1F566 # CLOCK FACE ELEVEN-THIRTY
+<Multi_key> <parenleft> <1> <2> <colon> <3> <0> <parenright>     : "🕧" U1F567 # CLOCK FACE TWELVE-THIRTY
+# Real bitcoin symbol now.
+<Multi_key> <B> <bar> : "₿" U20BF  # BITCOIN SIGN

--- a/mappings/xcompose.yaml
+++ b/mappings/xcompose.yaml
@@ -1,0 +1,1001 @@
+"..": "…"  # HORIZONTAL ELLIPSIS
+"v..": "⋮"  # VERTICAL ELLIPSIS
+"c..": "⋯"  # MIDLINE HORIZONTAL ELLIPSIS
+"/..": "⋰"  # UP RIGHT DIAGONAL ELLIPSIS
+".\\.": "⋱"  # DOWN RIGHT DIAGONAL ELLIPSIS
+"2.": "‥"  # TWO DOT LEADER
+"c1.": "·"  # MIDDLE DOT (maybe I can remember the keystroke better?
+"./.": "⁒"  # COMMERCIAL MINUS SIGN
+"&@": "⅋"  # TURNED AMPERSAND
+"&7": "⁊"  # TIRONIAN SIGN ET
+"\\ ": "␣"  # OPEN BOX
+"-- ": "– "  # EN DASH (followed by space)
+"-~-": "―"  # HORIZONTAL BAR
+"-2M": "⸺"  # TWO-EM DASH
+"-3M": "⸻"  # THREE-EM DASH
+"\\-": "­"  # SOFT HYPHEN
+" -": " — "  # EM DASH surrounded by THIN SPACEs.
+", ": "‚"  # SINGLE LOW-9 QUOTATION MARK
+",,": "„"  # DOUBLE LOW-9 QUOTATION MARK
+"<,,": "⹂"  # DOUBLE LOW-REVERSED-9 QUOTATION MARK
+"' ": "’"  # RIGHT SINGLE QUOTATION MARK
+"''": "”"  # RIGHT DOUBLE QUOTATION MARK
+"` ": "‘"  # LEFT SINGLE QUOTATION MARK
+"``": "“"  # LEFT DOUBLE QUOTATION MARK
+"6'": "‘"  # LEFT SINGLE QUOTATION MARK (high 6)
+"6\"": "“"  # LEFT DOUBLE QUOTATION MARK (66)
+"9'": "’"  # RIGHT SINGLE QUOTATION MARK (high 9)
+"9\"": "”"  # RIGHT DOUBLE QUOTATION MARK (99)
+"<9'": "‛"  # SINGLE HIGH-REVERSED-9 QUOTATION MARK
+"<9\"": "‟"  # DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+",'": "‚"  # SINGLE LOW-9 QUOTATION MARK (quote resembling a comma)
+",\"": "„"  # DOUBLE LOW-9 QUOTATION MARK
+" \"": " “"  # space followed by LEFT DOUBLE QUOTATION MARK
+"\" ": "” "  # RIGHT DOUBLE QUOTATION MARK followed by space
+" '": " ‘"  # space followed by LEFT SINGLE QUOTATION MARK
+"nt": "n’t "  # Apostrophized English “not.”
+" t": " the "
+" T": "  The "
+" a": " and "
+"im": " I’m "
+"ve": "’ve "
+",@": "⸲"  # TURNED COMMA
+".^": "⸳"  # RAISED DOT
+".~": "⸳"  # RAISED DOT
+",^": "⸴"  # RAISED COMMA
+";@": "⸵"  # TURNED SEMICOLON
+"~|": "ⸯ"  # VERTICAL TILDE
+"^|": "ⸯ"  # VERTICAL TILDE
+"-=": "⹀"  # DOUBLE HYPHEN
+",<": "⹁"  # REVERSED COMMA
+"<|": "↵"  # DOWNWARDS ARROW WITH CORNER LEFTWARDS
+"*1": "•"  # BULLET
+"o_": "⁃"  # HYPHEN BULLET
+"o,": "·"  # MIDDLE DOT
+" n": " "  # NARROW NO-BREAK SPACE
+" #": " "  # FIGURE SPACE
+"\\,": " "  # THIN SPACE
+" |": " "  # HAIR SPACE
+"dag": "†"  # DAGGER
+"ddag": "‡"  # DOUBLE DAGGER
+"sec": "§"  # SECTION SIGN
+"\"\"": "〃"  # DITTO MARK
+"7^[": "⸢"  # TOP LEFT HALF BRACKET
+"7^]": "⸣"  # TOP RIGHT HALF BRACKET
+"L_[": "⸤"  # BOTTOM LEFT HALF BRACKET
+"L_]": "⸥"  # BOTTOM RIGHT HALF BRACKET
+"-<": "←"  # LEFTWARDS ARROW
+"-^": "↑"  # UPWARDS ARROW
+"->": "→"  # RIGHTWARDS ARROW
+"-v": "↓"  # DOWNWARDS ARROW
+"<->": "↔"  # LEFT RIGHT ARROW (kragen's)
+"zz>": "↯"  # DOWNWARDS ZIGZAG ARROW
+"fv": "✌"  # VICTORY HAND
+"fw": "✍"  # WRITING HAND
+"=>": "⇒"  # RIGHTWARDS DOUBLE ARROW
+"=<": "⇐"  # LEFTWARDS DOUBLE ARROW
+"<-=>": "⇔"  # LEFT RIGHT DOUBLE ARROW
+"=.=": "⸎"  # EDITORIAL CORONIS
+"palm": "⸙"  # PALM BRANCH
+"branch": "⸙"  # PALM BRANCH
+"ff": "ﬀ"  # LATIN SMALL LIGATURE FF
+"fi": "ﬁ"  # LATIN SMALL LIGATURE FI
+"Fi": "ﬃ"  # LATIN SMALL LIGATURE FFI
+"fl": "ﬂ"  # LATIN SMALL LIGATURE FL
+"Fl": "ﬄ"  # LATIN SMALL LIGATURE FFL
+"st": "ﬆ"  # LATIN SMALL LIGATURE ST
+"ft": "ﬅ"  # LATIN SMALL LIGATURE LONG S T
+"ſt": "ﬅ"  # LATIN SMALL LIGATURE LONG S T
+"SS": "ẞ"  # LATIN CAPITAL LETTER SHARP S
+"F<": "ꟻ"  # LATIN EPIGRAPHIC LETTER REVERSED F
+"P<": "ꟼ"  # LATIN EPIGRAPHIC LETTER REVERSED P
+"FF": "Ⅎ"  # TURNED CAPITAL F
+"Ff": "ⅎ"  # TURNED SMALL F
+"MW": "ꟽ"  # LATIN EPIGRAPHIC LETTER INVERTED M
+"MM": "Ɯ"  # LATIN CAPITAL LETTER TURNED M
+"I|": "ꟾ"  # LATIN EPIGRAPHIC LETTER I LONGA
+"M/": "ꟿ"  # LATIN EPIGRAPHIC LETTER ARCHAIC M
+"22": "↊"  # TURNED DIGIT TWO
+"33": "↋"  # TURNED DIGIT THREE
+"E<": "Ǝ"  # LATIN CAPITAL LETTER REVERSED E
+"e<": "ɘ"  # LATIN SMALL LETTER REVERSED E
+"A<": "Ɐ"  # LATIN CAPITAL LETTER TURNED A
+"o&o": "ꝏ"  # LATIN SMALL LETTER OO
+"O&O": "Ꝏ"  # LATIN CAPITAL LETTER OO
+"2o": "ꝏ"  # LATIN SMALL LETTER OO
+"2O": "Ꝏ"  # LATIN CAPITAL LETTER OO
+"A&A": "Ꜳ"  # LATIN CAPITAL LETTER AA
+"a&a": "ꜳ"  # LATIN SMALL LETTER AA
+"2A": "Ꜳ"  # LATIN CAPITAL LETTER AA
+"2a": "ꜳ"  # LATIN SMALL LETTER AA
+"A&O": "Ꜵ"  # LATIN CAPITAL LETTER AO
+"a&o": "ꜵ"  # LATIN SMALL LETTER AO
+"A&U": "Ꜷ"  # LATIN CAPITAL LETTER AU
+"a&u": "ꜷ"  # LATIN SMALL LETTER AU
+"A&V": "Ꜹ"  # LATIN CAPITAL LETTER AV
+"a&v": "ꜹ"  # LATIN SMALL LETTER AV
+"A&Y": "Ꜽ"  # LATIN CAPITAL LETTER AY
+"a&y": "ꜽ"  # LATIN SMALL LETTER AY
+"/&L": "Ꝇ"  # LATIN CAPITAL LETTER BROKEN L
+"/&l": "ꝇ"  # LATIN SMALL LETTER BROKEN L
+"Z.": "Ꝫ"  # LATIN CAPITAL LETTER ET
+"z.": "ꝫ"  # LATIN SMALL LETTER ET
+"V&Y": "Ꝡ"  # LATIN CAPITAL LETTER VY
+"v&y": "ꝡ"  # LATIN SMALL LETTER VY
+"CZ": "Ꝣ"  # LATIN CAPITAL LETTER VISIGOTHIC Z
+"cz": "ꝣ"  # LATIN SMALL LETTER VISIGOTHIC Z
+"L&L": "Ỻ"  # LATIN CAPITAL LETTER MIDDLE-WELSH LL
+"l&l": "ỻ"  # LATIN SMALL LETTER MIDDLE-WELSH LL
+"V&V": "Ỽ"  # LATIN CAPITAL LETTER MIDDLE-WELSH V
+"v&v": "ỽ"  # LATIN SMALL LETTER MIDDLE-WELSH V
+"d&b": "ȸ"  # LATIN SMALL LETTER DB DIGRAPH
+"q&p": "ȹ"  # LATIN SMALL LETTER QP DIGRAPH
+"wy": "ƿ"  # LATIN LETTER WYNN
+"WY": "Ƿ"  # LATIN CAPITAL LETTER WYNN
+"OU": "Ȣ"  # LATIN CAPITAL LETTER OU
+"ou": "ȣ"  # LATIN SMALL LETTER OU
+"yr": "Ʀ"  # LATIN LETTER YR
+"ro": "ꝛ"  # LATIN SMALL LETTER R ROTUNDA
+"r0": "ꝛ"  # LATIN SMALL LETTER R ROTUNDA
+"RO": "Ꝛ"  # LATIN CAPITAL LETTER R ROTUNDA
+"R0": "Ꝛ"  # LATIN CAPITAL LETTER R ROTUNDA
+"!=": "≠"  # NOT EQUAL TO
+"/=": "≠"  # NOT EQUAL TO
+"<=": "≤"  # LESS-THAN OR EQUAL TO
+">=": "≥"  # GREATER-THAN OR EQUAL TO
+"!<>": "≸"  # NEITHER LESS-THAN NOR GREATER-THAN
+"+<": "≪"  # MUCH LESS-THAN
+"+>": "≫"  # MUCH GREATER-THAN
+"++<": "⋘"  # VERY MUCH LESS-THAN
+"++>": "⋙"  # VERY MUCH GREATER-THAN
+"3>": "⋙"  # VERY MUCH GREATER-THAN
+"3<": "⋘"  # VERY MUCH LESS-THAN
+"in": "∈"  # ELEMENT OF
+"!in": "∉"  # NOT AN ELEMENT OF
+"∈/": "∉"  # NOT AN ELEMENT OF (I have ∈ on my keyboard...)
+".∈": "∊"  # SMALL ELEMENT OF
+".∋": "∍"  # SMALL CONTAINS AS MEMBER
+"ni": "∋"  # CONTAINS AS MEMBER  (I hope this doesn't conflict)
+"/ni": "∌"  # DOES NOT CONTAIN AS MEMBER
+"∋/": "∌"  # DOES NOT CONTAIN AS MEMBER
+"~=": "≅"  # APPROXIMATELY EQUAL TO (It actually means "congruent"!)
+"=?": "≟"  # QUESTIONED EQUAL TO
+"=def": "≝"  # EQUAL TO BY DEFINITION
+"def=": "≝"  # EQUAL TO BY DEFINITION
+"==": "≡"  # IDENTICAL TO
+":=": "≔"  # COLON EQUALS
+"=:": "≕"  # EQUALS COLON
+"2=": "⩵"  # TWO CONSECUTIVE EQUALS SIGNS
+"=&=": "⩵"  # TWO CONSECUTIVE EQUALS SIGNS
+"3=": "⩶"  # THREE CONSECUTIVE EQUALS SIGNS
+"=|=": "≢"  # NOT IDENTICAL TO
+"-+": "∓"  # MINUS OR PLUS SIGN
+"sq": "√"  # SQUARE ROOT
+"3sq": "∛"  # CUBE ROOT
+"4sq": "∜"  # FOURTH ROOT
+"/\\": "∧"  # LOGICAL AND
+"\\/": "∨"  # LOGICAL OR
+"\\_/": "⊻"  # XOR
+"-,": "¬"  # NOT SIGN
+"*o": "∘"  # RING OPERATOR (function composition)
+"*x": "⨯"  # CROSS PRODUCT
+"*.": "⋅"  # DOT OPERATOR (dot product)
+"0/": "∅"  # EMPTY SET (thanks jsled!)
+"/0": "∅"  # EMPTY SET
+"{U": "∪"  # UNION
+"{^": "∩"  # INTERSECTION
+"{(": "⊂"  # SUBSET OF
+"{=(": "⊆"  # SUBSET OF OR EQUAL TO
+"!{(": "⊄"  # NOT A SUBSET OF
+"/{(": "⊄"  # NOT A SUBSET OF
+"!{)": "⊅"  # NOT A SUPERSET OF
+"/{)": "⊅"  # NOT A SUPERSET OF
+"{)": "⊃"  # SUPERSET OF
+"{=)": "⊇"  # SUPERSET OF OR EQUAL TO
+"EE": "∃"  # THERE EXISTS
+"/EE": "∄"  # THERE DOES NOT EXIST
+"AA": "∀"  # FOR ALL
+"QED": "∎"  # END OF PROOF
+"88": "∞"  # INFINITY
+"aleph": "ℵ"  # ALEF SYMBOL
+"alep0": "ℵ₀"  # ALEF Null
+"alep1": "ℵ₁"  # ALEF One
+"alef": "ℵ"  # ALEF SYMBOL
+"**": "∗"  # ASTERISK OPERATOR
+"(+)": "⊕"  # CIRCLED PLUS
+"(-)": "⊖"  # CIRCLED MINUS
+"(xx)": "⊗"  # CIRCLED TIMES
+"(/)": "⊘"  # CIRCLED DIVISION SLASH
+"(*)": "⊛"  # CIRCLED ASTERISK OPERATOR
+")_": "⟌"  # LONG DIVISION
+".\"": "∴"  # THEREFORE
+"there4": "∴"  # THEREFORE
+"\".": "∵"  # BECAUSE
+"because": "∵"  # BECAUSE
+"%%": "‱"  # PER TEN THOUSAND (basis points)
+"/u": "µ"  # MICRO SIGN
+"-a": "ª"  # FEMININE ORDINAL INDICATOR
+"-o": "º"  # MASCULINE ORDINAL INDICATOR
+"sum": "∑"  # N-ARY SUMMATION
+"int": "∫"  # INTEGRAL
+"uint": "⨛"  # UPPER INTEGRAL
+"lint": "⨜"  # LOWER INTEGRAL
+"iint": "∬"  # DOUBLE INTEGRAL
+"iiint": "∭"  # TRIPLE INTEGRAL
+"iiiint": "⨌"  # QUADRUPLE INTEGRAL
+"oint": "∮"  # CONTOUR INTEGRAL
+"pint": "⨕"  # INTEGRAL AROUND A POINT OPERATOR
+"cPint": "⨓"  # LINE INTEGRATION WITH SEMICIRCULAR PATH AROUND POLE
+"oiint": "∯"  # SURFACE INTEGRAL
+"oiiint": "∰"  # VOLUME INTEGRAL
+"gint": "⨘"  # GEOMETRIC INTEGRAL
+"sint": "⨋"  # SUM/INTEGRAL
+"del": "∇"  # NABLA
+"part": "∂"  # PARTIAL DIFFERENTIAL
+"*..d": "∂"  # PARTIAL DIFFERENTIAL
+"Re": "ℜ"  # BLACK-LETTER CAPITAL R (Real Part)
+"Im": "ℑ"  # BLACK-LETTER CAPTIAL I (Imaginary Part)
+"hbar": "ℏ"  # PLANCK CONSTANT OVER TWO PI
+"h-": "ℏ"  # PLANCK CONSTANT OVER TWO PI
+"hp": "ℎ"  # PLANCK CONSTANT
+"exp": "ℯ"  # SCRIPT SMALL E
+"e10": "⏨"  # DECIMAL EXPONENT SYMBOL
+"wp": "℘"  # SCRIPT CAPITAL P
+"^>": "⃗"  # COMBINING RIGHT ARROW ABOVE (vector)
+"|C": "ℂ"  # DOUBLE-STRUCK CAPITAL C (set of complex numbers)
+"|N": "ℕ"  # DOUBLE-STRUCK CAPITAL N (natural number)
+"|P": "ℙ"  # DOUBLE-STRUCK CAPITAL P
+"|Q": "ℚ"  # DOUBLE-STRUCK CAPITAL Q (set of rational numbers)
+"|R": "ℝ"  # DOUBLE-STRUCK CAPITAL R (set of real numbers)
+"|Z": "ℤ"  # DOUBLE-STRUCK CAPITAL Z (set of integers)
+"|H": "ℍ"  # DOUBLE-STRUCK CAPITAL H
+"|e": "ⅇ"  # DOUBLE-STRUCK ITALIC SMALL E
+"|i": "ⅈ"  # DOUBLE-STRUCK ITALIC SMALL I
+"|j": "ⅉ"  # DOUBLE-STRUCK ITALIC SMALL J
+"|*p": "ℼ"  # DOUBLE-STRUCK SMALL PI
+"|*P": "ℿ"  # DOUBLE-STRUCK CAPITAL PI
+"|*S": "⅀"  # DOUBLE-STRUCK N-ARY SUMMATION
+"|:": "⦂"  # Z NOTATION TYPE COLON
+"|;": "⨾"  # Z NOTATION RELATIONAL COMPOSITION
+"|{": "⦃"  # LEFT WHITE CURLY BRACKET
+"|}": "⦄"  # RIGHT WHITE CURLY BRACKET
+"S(": "⟅"  # LEFT S-SHAPED BAG DELIMITER
+"S)": "⟆"  # RIGHT S-SHAPED BAG DELIMITER
+"E[": "⁅"  # LEFT SQUARE BRACKET WITH QUILL
+"E]": "⁆"  # RIGHT SQUARE BRACKET WITH QUILL
+"<(": "⟨"  # MATHEMATICAL LEFT ANGLE BRACKET
+">)": "⟩"  # MATHEMATICAL RIGHT ANGLE BRACKET
+"|[": "⟦"  # MATHEMATICAL LEFT WHITE SQUARE BRACKET
+"|]": "⟧"  # MATHEMATICAL RIGHT WHITE SQUARE BRACKET
+"2<(": "⟪"  # MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
+"2>)": "⟫"  # MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+"||(": "⟬"  # MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
+"||)": "⟭"  # MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
+"__(": "⟮"  # MATHEMATICAL LEFT FLATTENED PARENTHESIS
+"__)": "⟯"  # MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+"([": "⦗"  # LEFT BLACK TORTOISE SHELL BRACKET
+")]": "⦘"  # RIGHT BLACK TORTOISE SHELL BRACKET
+"%(": "⧘"  # LEFT WIGGLY FENCE
+"%)": "⧙"  # RIGHT WIGGLY FENCE
+"2%(": "⧚"  # LEFT DOUBLE WIGGLY FENCE
+"2%)": "⧛"  # RIGHT DOUBLE WIGGLY FENCE
+"(&(": "⸨"  # LEFT DOUBLE PARENTHESIS
+")&)": "⸩"  # RIGHT DOUBLE PARENTHESIS
+"2(": "⸨"  # LEFT DOUBLE PARENTHESIS
+"2)": "⸩"  # RIGHT DOUBLE PARENTHESIS
+"Z(": "༼"  # TIBETAN MARK ANG KHANG GYON
+"Z)": "༽"  # TIBETAN MARK ANG KHANG GYAS
+"L[": "⌊"  # LEFT FLOOR
+"L]": "⌋"  # RIGHT FLOOR
+"7[": "⌈"  # LEFT CEILING
+"7]": "⌉"  # RIGHT CEILING
+"7'": "｢"  # HALFWIDTH LEFT CORNER BRACKET
+"L'": "｣"  # HALFWIDTH RIGHT CORNER BRACKET
+"7\"": "『"  # LEFT WHITE CORNER BRACKET
+"L\"": "』"  # RIGHT WHITE CORNER BRACKET
+"7(": "⌜"  # TOP LEFT CORNER
+"7)": "⌝"  # TOP RIGHT CORNER
+"L(": "⌞"  # BOTTOM LEFT CORNER
+"L)": "⌟"  # BOTTOM RIGHT CORNER
+"(&)": "≬"  # BETWEEN
+"ll": "ℓ"  # SCRIPT SMALL L
+"[[": "⊏"  # SQUARE IMAGE OF
+"[=": "⊑"  # SQUARE IMAGE OF OR EQUAL TO
+"[_": "⊑"  # SQUARE IMAGE OF OR EQUAL TO
+"]]": "⊐"  # SQUARE ORIGINAL OF
+"]=": "⊒"  # SQUARE ORIGINAL OF OR EQUAL TO
+"]_": "⊒"  # SQUARE ORIGINAL OF OR EQUAL TO
+"_|_": "⊥"  # UP TACK (bottom) or should we use U27C2 PERPENDICULAR?
+"_!_": "⊤"  # DOWN TACK (opposite of False)
+"_>_": "⊢"  # RIGHT TACK
+"_<_": "⊣"  # LEFT TACK
+"//": "⁄"  # FRACTION SLASH
+"_0": "₀"  # SUBSCRIPT ZERO
+"_1": "₁"  # SUBSCRIPT ONE
+"_2": "₂"  # SUBSCRIPT TWO
+"_3": "₃"  # SUBSCRIPT THREE
+"_4": "₄"  # SUBSCRIPT FOUR
+"_5": "₅"  # SUBSCRIPT FIVE
+"_6": "₆"  # SUBSCRIPT SIX
+"_7": "₇"  # SUBSCRIPT SEVEN
+"_8": "₈"  # SUBSCRIPT EIGHT
+"_9": "₉"  # SUBSCRIPT NONE
+"_+": "₊"  # SUBSCRIPT PLUS
+"_-": "₋"  # SUBSCRIPT MINUS
+"_=": "₌"  # SUBSCRIPT EQUALS SIGN
+"_(": "₍"  # SUBSCRIPT LEFT PARENTHESIS
+"_)": "₎"  # SUBSCRIPT RIGHT PARENTHESIS
+"_a": "ₐ"  # LATIN SUBSCRIPT SMALL LETTER A
+"_e": "ₑ"  # LATIN SUBSCRIPT SMALL LETTER E
+"_o": "ₒ"  # LATIN SUBSCRIPT SMALL LETTER O
+"_x": "ₓ"  # LATIN SUBSCRIPT SMALL LETTER X
+"_h": "ₕ"  # LATIN SUBSCRIPT SMALL LETTER H
+"_k": "ₖ"  # LATIN SUBSCRIPT SMALL LETTER K
+"_l": "ₗ"  # LATIN SUBSCRIPT SMALL LETTER L
+"_m": "ₘ"  # LATIN SUBSCRIPT SMALL LETTER M
+"_n": "ₙ"  # LATIN SUBSCRIPT SMALL LETTER N
+"_p": "ₚ"  # LATIN SUBSCRIPT SMALL LETTER P
+"_s": "ₛ"  # LATIN SUBSCRIPT SMALL LETTER S
+"_t": "ₜ"  # LATIN SUBSCRIPT SMALL LETTER T
+"_i": "ᵢ"  # LATIN SUBSCRIPT SMALL LETTER I
+"_j": "ⱼ"  # LATIN SUBSCRIPT SMALL LETTER J
+"_r": "ᵣ"  # LATIN SUBSCRIPT SMALL LETTER R
+"_u": "ᵤ"  # LATIN SUBSCRIPT SMALL LETTER U
+"_v": "ᵥ"  # LATIN SUBSCRIPT SMALL LETTER V
+"_*b": "ᵦ"  # GREEK SUBSCRIPT SMALL LETTER BETA
+"_*g": "ᵧ"  # GREEK SUBSCRIPT SMALL LETTER GAMMA
+"_*r": "ᵨ"  # GREEK SUBSCRIPT SMALL LETTER RHO
+"_*f": "ᵩ"  # GREEK SUBSCRIPT SMALL LETTER PHI
+"_*x": "ᵪ"  # GREEK SUBSCRIPT SMALL LETTER CHI
+"*a": "α"  # GREEK SMALL LETTER ALPHA
+"*b": "β"  # GREEK SMALL LETTER BETA
+"*c": "ψ"  # GREEK SMALL LETTER PSI
+"*d": "δ"  # GREEK SMALL LETTER DELTA
+"*e": "ε"  # GREEK SMALL LETTER EPSILON
+"*f": "φ"  # GREEK SMALL LETTER PHI
+"*g": "γ"  # GREEK SMALL LETTER GAMMA
+"*h": "η"  # GREEK SMALL LETTER ΕΤΑ
+"*i": "ι"  # GREEK SMALL LETTER ΙΟΤΑ
+"*j": "ξ"  # GREEK SMALL LETTER XI
+"*k": "κ"  # GREEK SMALL LETTER KAPPA
+"*l": "λ"  # GREEK SMALL LETTER LAMBDA
+"*m": "μ"  # GREEK SMALL LETTER MU
+"*n": "ν"  # GREEK SMALL LETTER NU
+"*o": "ο"  # GREEK SMALL LETTER OMICRON
+"*p": "π"  # GREEK SMALL LETTER PI
+"*.?": ";"  # GREEK QUESTION MARK
+"*r": "ρ"  # GREEK SMALL LETTER RHO
+"*s": "σ"  # GREEK SMALL LETTER SIGMA
+"*t": "τ"  # GREEK SMALL LETTER TAU
+"*u": "θ"  # GREEK SMALL LETTER THETA
+"*v": "ω"  # GREEK SMALL LETTER OMEGA
+"*w": "ς"  # GREEK SMALL LETTER FINAL SIGMA
+"*x": "χ"  # GREEK SMALL LETTER CHI
+"*y": "υ"  # GREEK SMALL LETTER UPSILON
+"*z": "ζ"  # GREEK SMALL LETTER ZETA
+"*A": "Α"  # GREEK CAPITAL LETTER ALPHA
+"*B": "Β"  # GREEK CAPITAL LETTER BETA
+"*C": "Ψ"  # GREEK CAPITAL LETTER PSI
+"*D": "Δ"  # GREEK CAPITAL LETTER DELTA
+"*E": "Ε"  # GREEK CAPITAL LETTER EPSILON
+"*F": "Φ"  # GREEK CAPITAL LETTER PHI
+"*G": "Γ"  # GREEK CAPITAL LETTER GAMMA
+"*H": "Η"  # GREEK CAPITAL LETTER ΕΤΑ
+"*I": "Ι"  # GREEK CAPITAL LETTER ΙΟΤΑ
+"*J": "Ξ"  # GREEK CAPITAL LETTER XI
+"*K": "Κ"  # GREEK CAPITAL LETTER KAPPA
+"*L": "Λ"  # GREEK CAPITAL LETTER LAMBDA
+"*M": "Μ"  # GREEK CAPITAL LETTER MU
+"*N": "Ν"  # GREEK CAPITAL LETTER NU
+"*O": "Ο"  # GREEK CAPITAL LETTER OMICRON
+"*P": "Π"  # GREEK CAPITAL LETTER PI
+"*R": "Ρ"  # GREEK CAPITAL LETTER RHO
+"*S": "Σ"  # GREEK CAPITAL LETTER SIGMA
+"*T": "Τ"  # GREEK CAPITAL LETTER TAU
+"*U": "Θ"  # GREEK CAPITAL LETTER THETA
+"*V": "Ω"  # GREEK CAPITAL LETTER OMEGA
+"*X": "Χ"  # GREEK CAPITAL LETTER CHI
+"*Y": "Υ"  # GREEK CAPITAL LETTER UPSILON
+"*Z": "Ζ"  # GREEK CAPITAL LETTER ZETA
+"*.p": "ϖ"  # GREEK PI SYMBOL
+"*.w": "ϝ"  # GREEK SMALL LETTER DIGAMMA
+"*.W": "Ϝ"  # GREEK CAPITAL LETTER DIGAMMA
+"*Q": "Ϟ"  # GREEK LETTER QOPPA
+"*q": "ϟ"  # GREEK SMALL LETTER QOPPA
+"*.Q": "Ϙ"  # GREEK LETTER ARCHAIC QOPPA
+"*.q": "ϙ"  # GREEK SMALL LETTER ARCHAIC QOPPA
+"*&": "ϗ"  # GREEK KAI SYMBOL
+"*.Z": "Ϡ"  # GREEK LETTER SAMPI
+"*.z": "ϡ"  # GREEK SMALL LETTER SAMPI
+"*..Z": "Ͳ"  # GREEK CAPITAL LETTER ARCHAIC SAMPI
+"*..z": "ͳ"  # GREEK SMALL LETTER ARCHAIC SAMPI
+"*?": "Ϛ"  # GREEK LETTER STIGMA
+"*/": "ϛ"  # GREEK SMALL LETTER STIGMA
+"*'": "ʹ"  # MODIFIER LETTER PRIME, canonically equivalent to U0374 GREEK NUMERAL SIGN
+"*.'": "′"  # PRIME
+"*.\"": "″"  # DOUBLE PRIME
+"*,": "͵"  # GREEK LOWER NUMERAL SIGN (for thousands)
+"*.b": "ϐ"  # GREEK BETA SYMBOL
+"*.u": "ϑ"  # GREEK THETA SYMBOL
+"*.Y": "ϒ"  # GREEK UPSILON WITH HOOK SYMBOL
+"*.f": "ϕ"  # GREEK PHI SYMBOL
+"*.k": "ϰ"  # GREEK KAPPA SYMBOL
+"*.r": "ϱ"  # GREEK RHO SYMBOL
+"*.U": "ϴ"  # GREEK CAPITAL THETA SYMBOL
+"*.e": "ϵ"  # GREEK LUNATE EPSILON SYMBOL
+"*.s": "ϻ"  # GREEK SMALL LETTER SAN
+"*.S": "Ϻ"  # GREEK CAPITAL LETTER SAN
+"13": "⅓"  # VULGAR FRACTION ONE THIRD
+"23": "⅔"  # VULGAR FRACTION TWO THIRDS
+"15": "⅕"  # VULGAR FRACTION ONE FIFTH
+"25": "⅖"  # VULGAR FRACTION TWO FIFTHS
+"35": "⅗"  # VULGAR FRACTION THREE FIFTHS
+"45": "⅘"  # VULGAR FRACTION FOUR FIFTHS
+"16": "⅙"  # VULGAR FRACTION ONE SIXTH
+"56": "⅚"  # VULGAR FRACTION FIVE SIXTHS
+"18": "⅛"  # VULGAR FRACTION ONE EIGHTH
+"38": "⅜"  # VULGAR FRACTION THREE EIGHTHS
+"58": "⅝"  # VULGAR FRACTION FIVE EIGHTHS
+"78": "⅞"  # VULGAR FRACTION SEVEN EIGHTHS
+"17": "⅐"  # VULGAR FRACTION ONE SEVENTH
+"19": "⅑"  # VULGAR FRACTION ONE NINTH
+"1x": "⅒"  # VULGAR FRACTION ONE TENTH
+"03": "↉"  # VULGAR FRACTION ZERO THIRDS
+"1/": "⅟"  # FRACTION NUMERATOR ONE
+"%1": "ⅰ"  # SMALL ROMAN NUMERAL ONE
+"%2": "ⅱ"  # SMALL ROMAN NUMERAL TWO
+"%3": "ⅲ"  # SMALL ROMAN NUMERAL THREE
+"%4": "ⅳ"  # SMALL ROMAN NUMERAL FOUR
+"%5": "ⅴ"  # SMALL ROMAN NUMERAL FIVE
+"%6": "ⅵ"  # SMALL ROMAN NUMERAL SIX
+"%7": "ⅶ"  # SMALL ROMAN NUMERAL SEVEN
+"%8": "ⅷ"  # SMALL ROMAN NUMERAL EIGHT
+"%9": "ⅸ"  # SMALL ROMAN NUMERAL NINE
+"%x": "ⅹ"  # SMALL ROMAN NUMERAL TEN
+"%_1": "ⅺ"  # SMALL ROMAN NUMERAL ELEVEN
+"%_2": "ⅻ"  # SMALL ROMAN NUMERAL TWELVE
+"%l": "ⅼ"  # SMALL ROMAN NUMERAL FIFTY
+"%c": "ⅽ"  # SMALL ROMAN NUMERAL ONE HUNDRED
+"%d": "ⅾ"  # SMALL ROMAN NUMERAL FIVE HUNDRED
+"%m": "ⅿ"  # SMALL ROMAN NUMERAL ONE THOUSAND
+"%01": "Ⅰ"  # ROMAN NUMERAL ONE
+"%02": "Ⅱ"  # ROMAN NUMERAL TWO
+"%03": "Ⅲ"  # ROMAN NUMERAL THREE
+"%04": "Ⅳ"  # ROMAN NUMERAL FOUR
+"%05": "Ⅴ"  # ROMAN NUMERAL FIVE
+"%06": "Ⅵ"  # ROMAN NUMERAL SIX
+"%07": "Ⅶ"  # ROMAN NUMERAL SEVEN
+"%08": "Ⅷ"  # ROMAN NUMERAL EIGHT
+"%09": "Ⅸ"  # ROMAN NUMERAL NINE
+"%0x": "Ⅹ"  # ROMAN NUMERAL TEN
+"%_01": "Ⅺ"  # ROMAN NUMERAL ELEVEN
+"%_02": "Ⅻ"  # ROMAN NUMERAL TWELVE
+"%0l": "Ⅼ"  # ROMAN NUMERAL FIFTY
+"%0c": "Ⅽ"  # ROMAN NUMERAL ONE HUNDRED
+"%0d": "Ⅾ"  # ROMAN NUMERAL FIVE HUNDRED
+"%0m": "Ⅿ"  # ROMAN NUMERAL ONE THOUSAND
+"%X": "Ⅹ"  # ROMAN NUMERAL TEN
+"%L": "Ⅼ"  # ROMAN NUMERAL FIFTY
+"%C": "Ⅽ"  # ROMAN NUMERAL ONE HUNDRED
+"%<C": "Ↄ"  # ROMAN NUMERAL REVERSED ONE HUNDRED
+"%D": "Ⅾ"  # ROMAN NUMERAL FIVE HUNDRED
+"%M": "Ⅿ"  # ROMAN NUMERAL ONE THOUSAND
+"%0CD": "ↀ"  # ROMAN NUMERAL ONE THOUSAND C D
+"%0D": "ↁ"  # ROMAN NUMERAL FIVE THOUSAND
+"%0M": "ↂ"  # ROMAN NUMERAL TEN THOUSAND
+"%00D": "ↇ"  # ROMAN NUMERAL FIFTY THOUSAND
+"%00M": "ↈ"  # ROMAN NUMERAL ONE HUNDRED THOUSAND
+"(:": "☻"  # BLACK SMILING FACE
+":)": "☺"  # WHITE SMILING FACE
+":(": "☹"  # WHITE FROWNING FACE
+":~": "⍨"  # APL FUNCTIONAL SYMBOL TILDE DIAERESIS
+":|": "⸚"  # HYPHEN WITH DIAERESIS
+":oo)": "°͜°"  # Funny smiley-face.
+"O.O": "Ꙭ"  # CYRILLIC CAPITAL LETTER DOUBLE MONOCULAR O * used in the dual of words based on the root for 'eye'
+"o.o": "ꙭ"  # CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
+"O:": "Ꙫ"  # CYRILLIC CAPITAL LETTER BINOCULAR O * used in the dual of words based on the root for 'eye'
+"o:": "ꙫ"  # CYRILLIC SMALL LETTER BINOCULAR O
+"o+": "ꙮ"  # CYRILLIC LETTER MULTIOCULAR O * used in the epithet 'many-eyed'
+"o3": "߷"  # NKO SYMBOL GBAKURUNEN
+"!?": "‽"  # INTERROBANG
+"?!": "⸘"  # INVERTED INTERROBANG, standard now.
+"¿¡": "⸘"  # INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? "?i" maybe?
+"¡¿": "⸘"  # INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? "?i" maybe?
+"?<": "⸮"  # REVERSED QUESTION MARK
+"?&?": "⁇"  # DOUBLE QUESTION MARK
+"2?": "⁇"  # DOUBLE QUESTION MARK
+"?&!": "⁈"  # QUESTION EXCLAMATION MARK
+"!&?": "⁉"  # EXCLAMATION QUESTION MARK
+"!&!": "‼"  # DOUBLE EXCLAMATION MARK
+"2!": "‼"  # DOUBLE EXCLAMATION MARK
+"2:": "∷"  # PROPORTION -- not strictly 2 times COLON
+";<": "⁏"  # REVERSED SEMICOLON
+"<3": "♥"  # BLACK HEART SUIT
+"o8": "♣"  # BLACK CLUB SUIT
+"c3": "♣"  # BLACK CLUB SUIT
+"<>": "♢"  # WHITE DIAMOND SUIT
+"3-": "♠"  # BLACK SPADE SUIT
+"<}": "♠"  # BLACK SPADE SUIT
+"E>": "♡"  # WHITE HEART SUIT
+"shmrck": "☘"  # SHAMROCK
+"shamro": "☘"  # SHAMROCK
+"pc": "☮"  # PEACE SYMBOL
+"peace": "☮"  # PEACE SYMBOL
+"yy": "☯"  # YIN YANG
+"yinyan": "☯"  # YIN YANG
+"!<3": "❣"  # HEAVY HEART EXCLAMATION MARK ORNAMENT
+"f<3": "❦"  # FLORAL HEART
+"tel": "☎"  # BLACK TELEPHONE
+"tea": "☕"  # HOT BEVERAGE
+"[ ]": "☐"  # BALLOT BOX
+"chk": "☑"  # BALLOT BOX WITH CHECK
+"[/]": "☑"  # BALLOT BOX WITH CHECK
+"[x]": "☒"  # BALLOT BOX WITH X
+"@/": "✓"  # CHECK MARK
+"@@/": "✔"  # HEAVY CHECK MARK
+"@X": "✗"  # BALLOT X
+"@@X": "✘"  # HEAVY BALLOT X
+"@(": "❨"  # MEDIUM LEFT PARENTHESIS ORNAMENT
+"@)": "❩"  # MEDIUM RIGHT PARENTHESIS ORNAMENT
+"@@(": "❪"  # MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
+"@@)": "❫"  # MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
+"@<": "❬"  # MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
+"@>": "❭"  # MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
+"@@<": "❰"  # HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
+"@@>": "❱"  # HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
+"@[(": "❲"  # LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
+"@])": "❳"  # LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
+"@{": "❴"  # MEDIUM LEFT CURLY BRACKET ORNAMENT
+"@}": "❵"  # MEDIUM RIGHT CURLY BRACKET ORNAMENT
+"@": "️"  # Emoji selector
+"!": "︎"  # Text selector
+"[1]": "⚀"  # DIE FACE-1
+"[2]": "⚁"  # DIE FACE-2
+"[3]": "⚂"  # DIE FACE-3
+"[4]": "⚃"  # DIE FACE-4
+"[5]": "⚄"  # DIE FACE-5
+"[6]": "⚅"  # DIE FACE-6
+"(CC)": "🅭"  # CIRCLED CC
+"C(CC)": "🅭"  # CIRCLED CC
+"(\\C)": "🅮"  # CIRCLED C WITH OVERLAID BACKSLASH
+"(/C)": "🅮"  # CIRCLED C WITH OVERLAID BACKSLASH
+"C(\\C)": "🅮"  # CIRCLED C WITH OVERLAID BACKSLASH
+"C(/C)": "🅮"  # CIRCLED C WITH OVERLAID BACKSLASH
+"C(BY)": "🅯"  # CIRCLED HUMAN FIGURE
+"C(SA)": "🄎"  # CIRCLED ANTICLOCKWISE ARROW
+"C(ND)": "⊜"  # CIRCLED EQUALS
+"C(=)": "⊜"  # CIRCLED EQUALS
+"C(NC)": "🄏"  # CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+"C(/$)": "🄏"  # CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+"C(\\$)": "🄏"  # CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+"(C<)": "🄯"  # COPYLEFT SYMBOL
+"C(C<)": "🄯"  # COPYLEFT SYMBOL
+"#0": "🯰"  # SEGMENTED DIGIT ZERO
+"#1": "🯱"  # SEGMENTED DIGIT ONE
+"#2": "🯲"  # SEGMENTED DIGIT TWO
+"#3": "🯳"  # SEGMENTED DIGIT THREE
+"#4": "🯴"  # SEGMENTED DIGIT FOUR
+"#5": "🯵"  # SEGMENTED DIGIT FIVE
+"#6": "🯶"  # SEGMENTED DIGIT SIX
+"#7": "🯷"  # SEGMENTED DIGIT SEVEN
+"#8": "🯸"  # SEGMENTED DIGIT EIGHT
+"#9": "🯹"  # SEGMENTED DIGIT NINE
+"fdl": "⚜"  # FLEUR-DE-LIS
+"atom": "⚛"  # ATOM SYMBOL
+"cccp": "☭"  # HAMMER AND SICKLE
+"/!\\": "⚠"  # WARNING SIGN
+"!^": "⚠"  # WARNING SIGN
+"zap": "⚡"  # HIGH VOLTAGE SIGN
+"rad": "☢"  # RADIOACTIVE SIGN
+"bh": "☣"  # BIOHAZARD SIGN
+"biohaz": "☣"  # BIOHAZARD SIGN
+"AAAAA": "⛤"  # PENTAGRAM (pentalpha, get it?)
+"plane": "✈"  # AIRPLANE
+"mail": "✉"  # ENVELOPE
+"whlch": "♿"  # WHEELCHAIR SYMBOL
+"med": "☤"  # CADEUCEUS
+"iwit": "👁️‍🗨️"
+"1med": "⚕"  # STAFF OF AESCULAPIUS
+"o-+": "♀"  # FEMALE SIGN
+"o->": "♂"  # MALE SIGN
+"gay": "⚣"  # DOUBLED MALE SIGN
+"lesbian": "⚢"  # DOUBLED FEMALE SIGN
+"hetero": "⚤"  # INTERLOCKED FEMALE AND MALE SIGN
+"trans": "⚥"  # MALE AND FEMALE SIGN
+"genderq": "⚧"  # MALE WITH STROKE AND MALE AND FEMALE SIGN
+"OX": "☠"  # SKULL AND CROSSBONES
+"death": "☠"  # SKULL AND CROSSBONES
+"Xbones": "☠"  # SKULL AND CROSSBONES
+"kbd": "⌨"  # KEYBOARD
+"rhand": "☞"  # WHITE RIGHT POINTING INDEX
+"lhand": "☜"  # WHITE LEFT POINTING INDEX
+"**": "★"  # BLACK STAR
+"*0": "☆"  # WHITE STAR
+"*-": "✪"  # CIRCLED WHITE STAR
+"*3": "⁂"  # ASTERISM
+"3*": "⁂"  # ASTERISM
+"2*": "⁑"  # TWO ASTERISKS ALIGNED VERTICALLY
+"*4": "✢"  # FOUR TEARDROP-SPOKED ASTERISK
+"*6": "✡"  # STAR OF DAVID
+"*#": "✯"  # PINWHEEL STAR
+"*!": "✱"  # HEAVY ASTERISK
+"<X>": "❖"  # BLACK DIAMOND MINUS WHITE X
+"@#": "⌘"  # PLACE OF INTEREST SIGN
+"`-'": "⚞"  # THREE LINES CONVERGING RIGHT
+"'-`": "⚟"  # THREE LINES CONVERGING LEFT
+"Bellsym": "⍾"  # BELL SYMBOL (or ALIENS LANDING) -- &-a-l-i-e-n ?
+"_^_": "⌤"  # UP ARROWHEAD BETWEEN TWO HORIZONTAL BARS; aka ENTER KEY, aka NOT AMUSED.
+"wait": "⌛"  # HOURGLASS
+"hour": "⌛"  # HOURGLASS
+"time": "⌚"  # WATCH
+"watch": "⌚"  # WATCH
+" N": " "  # EN SPACE
+" M": " "  # EM SPACE
+" 3M": " "  # THREE-PER-EM SPACE
+" 4M": " "  # FOUR-PER-EM SPACE
+" 6M": " "  # SIX-PER-EM SPACE
+" ,": " "  # PUNCTUATION SPACE
+" +": " "  # MEDIUM MATHEMATICAL SPACE
+"()": "◌"  # DOTTED CIRCLE
+"[]": "⬚"  # DOTTED SQUARE
+"*(": "﴾"  # ORNATE LEFT PARENTHESIS
+"*)": "﴿"  # ORNATE RIGHT PARENTHESIS
+"ks": "ʘ"  # LATIN LETTER BILABIAL CLICK (kiss sound)
+"|>": "‣"  # TRIANGULAR BULLET
+"^^h": "ʰ"  # SUPERSCRIPT H
+"^^i": "ⁱ"  # SUPERSCRIPT I
+"^^j": "ʲ"  # SUPERSCRIPT J
+"^^n": "ⁿ"  # SUPERSCRIPT N
+"^^r": "ʳ"  # SUPERSCRIPT R
+"^^w": "ʷ"  # SUPERSCRIPT W
+"^^y": "ʸ"  # SUPERSCRIPT Y
+"^^x": "ˣ"  # SUPERSCRIPT X
+"^^e": "ᵉ"  # MODIFIER LETTER SMALL E
+"^^t": "ᵗ"  # MODIFIER LETTER SMALL T
+"þt": "ꝥ"  # LATIN SMALL LETTER THORN WITH STROKE
+"^?.": "ˀ"  # MODIFIER LETTER GLOTTAL STOP
+"^?(": "ˁ"  # MODIFIER LETTER REVERSED GLOTTAL STOP
+"^-": "⁻"  # SUPERSCRIPT MINUS
+"^+": "⁺"  # SUPERSCRIPT PLUS
+"~~": "≈"  # ALMOST EQUAL TO
+"sh": "ʃ"  # LATIN SMALL LETTER ESH
+"zh": "ʒ"  # LATIN SMALL LETTER EZH
+"lh": "ɬ"  # LATIN SMALL LETTER L WITH BELT
+"l3": "ɮ"  # LATIN SMALL LETTER LEZH
+"yg": "ȝ"  # LATIN SMALL LETTER YOGH
+"YG": "Ȝ"  # LATIN CAPITAL LETTER YOGH
+"?.": "ʔ"  # LATIN LETTER GLOTTAL STOP
+"?(": "ʕ"  # LATIN LETTER PHARYNGEAL VOICED FRICATIVE
+"?v": "ʖ"  # LATIN LETTER INVERTED GLOTTAL STOP
+"?@": "ʖ"  # LATIN LETTER INVERTED GLOTTAL STOP
+"?-": "ʡ"  # LATIN LETTER GLOTTAL STOP WITH STROKE
+"?{": "ʢ"  # LATIN LETTER REVERSED GLOTTAL STOP WITH STROKE
+"ph": "ɸ"  # LATIN SMALL LETTER PHI
+"ih": "ɪ"  # LATIN LETTER SMALL CAPITAL I
+"IH": "ɪ"  # LATIN LETTER SMALL CAPITAL I
+"uh": "ʊ"  # LATIN SMALL LETTER UPSILON
+"UH": "ʊ"  # LATIN SMALL LETTER UPSILON
+"ah": "ɑ"  # LATIN SMALL LETTER ALPHA
+"er": "ɚ"  # LATIN SMALL LETTER SCHWA WITH HOOK
+"o)": "ɔ"  # LATIN SMALL LETTER OPEN O
+"aw": "ɔ"  # LATIN SMALL LETTER OPEN O
+"O)": "Ɔ"  # LATIN CAPITAL LETTER OPEN O
+"AW": "Ɔ"  # LATIN CAPITAL LETTER OPEN O
+"eh": "ɛ"  # LATIN SMALL LETTER OPEN E
+"<ah": "ɒ"  # LATIN SMALL LETTER TURNED ALPHA
+"<eh": "ɜ"  # LATIN SMALL LETTER REVERSED OPEN E
+"<er": "ɝ"  # LATIN SMALL LETTER REVERSED OPEN E WITH HOOK
+"gy": "ɟ"  # LATIN SMALL LETTER DOTLESS J WITH STROKE
+"|'": "ˈ"  # MODIFIER LETTER VERTICAL LINE
+"|,": "ˌ"  # MODIFIER LETTER LOW VERTICAL LINE
+"|_": "̩"  # COMBINING VERTICAL LINE BELOW
+"\\_|": "̩"  # COMBINING VERTICAL LINE BELOW
+"rr": "ɹ"  # LATIN SMALL LETTER TURNED R: voiced alveolar approximant (American English (at least) R)
+"rd": "ɾ"  # LATIN SMALL LETTER R WITH FISHHOOK: voiced alveolar flap or tap (American English intervocalic allophone of d, or Spanish r)
+"vv": "ʌ"  # LATIN SMALL LETTER TURNED V
+"ui": "ɯ"  # LATIN SMALL LETTER TURNED M
+"ww": "ʍ"  # LATIN SMALL LETTER TURNED W
+"yy": "ʎ"  # LATIN SMALL LETTER TURNED Y
+"aa": "ɐ"  # LATIN SMALL LETTER TURNED A
+"hh": "ɥ"  # LATIN SMALL LETTER TURNED H
+"j.": "ȷ"  # LATIN SMALL LETTER DOTLESS J
+"!.": "Ꞌ"  # LATIN CAPITAL LETTER SALTILLO
+"!_.": "ꞌ"  # LATIN SMALL LETTER SALTILLO
+"WW": "ʬ"  # LATIN LETTER BILABIAL PERCUSSIVE
+":+": "ː"  # MODIFIER LETTER TRIANGULAR COLON
+"gh": "ɣ"  # LATIN SMALL LETTER GAMMA
+"ogh": "ɤ"  # LATIN SMALL LETTER RAMS HORN
+"ain": "ᴥ"  # LATIN LETTER AIN
+"d,": "ɖ"  # LATIN SMALL LETTER D WITH TAIL
+"l,": "ɭ"  # LATIN SMALL LETTER L WITH RETROFLEX HOOK
+"n,": "ɳ"  # LATIN SMALL LETTER N WITH RETROFLEX HOOK
+"s,": "ʂ"  # LATIN SMALL LETTER S WITH HOOK
+"t,": "ʈ"  # LATIN SMALL LETTER T WITH RETROFLEX HOOK
+"z,": "ʐ"  # LATIN SMALL LETTER Z WITH RETROFLEX HOOK
+"f,": "ƒ"  # LATIN SMALL LETTER F WITH HOOK
+"b'": "ɓ"  # LATIN SMALL LETTER B WITH HOOK
+"d'": "ɗ"  # LATIN SMALL LETTER D WITH HOOK
+"g'": "ɠ"  # LATIN SMALL LETTER G WITH HOOK
+"gg": "ɡ"  # LATIN SMALL LETTER SCRIPT G
+"h'": "ɦ"  # LATIN SMALL LETTER H WITH HOOK
+"G'": "ʛ"  # LATIN LETTER SMALL CAPITAL G WITH HOOK
+"No": "№"  # NUMERO SIGN
+"Rx": "℞"  # PRESCRIPTION TAKE
+"Per": "⅌"  # PER SIGN
+"oz.": "℥"  # OUNCE SIGN
+"scr.": "℈"  # SCRUPLE
+"*...": "๛"  # THAI CHARACTER KHOMUT (end of chapter)
+"#b": "♭"  # MUSIC FLAT SIGN
+"#f": "♮"  # MUSIC NATURAL SIGN
+"#=": "♮"  # MUSIC NATURAL SIGN
+"##": "♯"  # MUSIC SHARP SIGN
+"#G": "𝄞"  # MUSICAL SYMBOL G CLEF
+"#F": "𝄢"  # MUSICAL SYMBOL F CLEF
+"#C": "𝄡"  # MUSICAL SYMBOL C CLEF
+"#o/": "♪"  # EIGHTH NOTE
+"#oo": "♫"  # BEAMED EIGHTH NOTES
+"#%": "♫"  # BEAMED EIGHTH NOTES
+"#q": "♩"  # QUARTER NOTE
+"#h": "𝅗𝅥"  # MUSICAL SYMBOL HALF NOTE
+"#w": "𝅝"  # MUSICAL SYMBOL WHOLE NOTE
+"\\`": "̀"  # COMBINING GRAVE ACCENT
+"\\'": "́"  # COMBINING ACUTE ACCENT
+"\\^": "̂"  # COMBINING CIRCUMFLEX ACCENT
+"\\~": "̃"  # COMBINING TILDE
+"\\=": "̄"  # COMBINING MACRON
+"\\\\=": "̅"  # COMBINING OVERLINE -- ???
+"\\U": "̆"  # COMBINING BREVE
+"\\.": "̇"  # COMBINING DOT ABOVE
+"\\\"": "̈"  # COMBINING DIAERESIS
+"\\?": "̉"  # COMBINING HOOK ABOVE
+"\\o": "̊"  # COMBINING RING ABOVE
+"\\0": "̊"  # COMBINING RING ABOVE
+"\\\\'": "̋"  # COMBINING DOUBLE ACUTE ACCENT -- ??
+"\\c": "̌"  # COMBINING CARON
+"\\|": "̍"  # COMBINING VERTICAL LINE ABOVE
+"\\2|": "̎"  # COMBINING DOUBLE VERTICAL LINE ABOVE
+"\\2`": "̏"  # COMBINING DOUBLE GRAVE ACCENT
+"\\\\\\,": "̒"  # COMBINING TURNED COMMA ABOVE
+"\\\\,": "̓"  # COMBINING COMMA ABOVE
+"\\\\<,": "̔"  # COMBINING REVERSED COMMA ABOVE
+"\\fm": "͒"  # COMBINING FERMATA
+"\\(.": "̐"  # COMBINING CHANDRABINDU
+"\\ib": "̑"  # COMBINING INVERTED BREVE -- ??
+"\\()": "⃝"  # COMBINING ENCLOSING CIRCLE
+"\\[q]": "⃞"  # COMBINING ENCLOSING SQUARE
+"\\[d]": "⃟"  # COMBINING ENCLOSING DIAMOND
+"\\(/)": "⃠"  # COMBINING ENCLOSING CIRCLE BACKSLASH
+"\\[s]": "⃢"  # COMBINING ENCLOSING SCREEN
+"\\[k]": "⃣"  # COMBINING ENCLOSING KEYCAP
+"\\[t]": "⃤"  # COMBINING ENCLOSING TRIANGLE
+"\\2/": "⃫"  # COMBINING LONG DOUBLE SOLIDUS OVERLAY
+"\\*": "⃰"  # COMBINING ASTERISK ABOVE
+"\\!": "̣"  # COMBINING DOT BELOW
+"\\__": "̱"  # COMBINING MACRON BELOW
+"\\\\_": "̲"  # COMBINING LOW LINE
+"\\\\\\_": "̳"  # COMBINING DOUBLE LOW LINE
+"\\@o": "̥"  # COMBINING RING BELOW
+"\\@c": "̬"  # COMBINING CARON BELOW
+"\\@^": "̭"  # COMBINING CIRCUMFLEX ACCENT BELOW
+"\\@U": "̮"  # COMBINING BREVE BELOW
+"\\@ib": "̯"  # COMBINING INVERTED BREVE BELOW -- ??
+"\\&@U": "͜"  # COMBINING DOUBLE BREVE BELOW
+"\\2@U": "͜"  # COMBINING DOUBLE BREVE BELOW
+"\\&U": "͝"  # COMBINING DOUBLE BREVE
+"\\2U": "͝"  # COMBINING DOUBLE BREVE
+"\\&-": "͞"  # COMBINING DOUBLE MACRON
+"\\2-": "͞"  # COMBINING DOUBLE MACRON
+"\\&@-": "͟"  # COMBINING DOUBLE MACRON BELOW
+"\\2@-": "͟"  # COMBINING DOUBLE MACRON BELOW
+"\\&_": "͟"  # COMBINING DOUBLE MACRON BELOW
+"\\2_": "͟"  # COMBINING DOUBLE MACRON BELOW
+"\\&~": "͠"  # COMBINING DOUBLE TILDE
+"\\2~": "͠"  # COMBINING DOUBLE TILDE
+"\\&ib": "͡"  # COMBINING DOUBLE INVERTED BREVE
+"\\2ib": "͡"  # COMBINING DOUBLE INVERTED BREVE
+"\\&@ib": "᷼"  # COMBINING DOUBLE INVERTED BREVE BELOW
+"\\2@ib": "᷼"  # COMBINING DOUBLE INVERTED BREVE BELOW
+"\\&>": "͢"  # COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+"\\2>": "͢"  # COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+".)": "͒"  # COMBINING FERMATA
+"\\\\*": "҉"  # COMBINING CYRILLIC MILLIONS SIGN  -- aka COMBINING SHINY
+"P-": "₽"  # RUBLE SIGN
+"p-": "₽"  # RUBLE SIGN
+"ZWSP": "​"  # ZERO WIDTH SPACE
+"ZWNJ": "‌"  # ZERO WIDTH NON-JOINER
+"ZWJ": "‍"  # ZERO WIDTH JOINER
+"LRM": "‎"  # LEFT-TO-RIGHT MARK
+"RLM": "‏"  # RIGHT-TO-LEFT MARK
+"LRE": "‪"  # LEFT-TO-RIGHT EMBEDDING
+"RLE": "‫"  # RIGHT-TO-LEFT EMBEDDING
+"PDF": "‬"  # POP DIRECTIONAL FORMATTING
+"LRI": "⁦"  # LEFT-TO-RIGHT ISOLATE
+"RLI": "⁧"  # RIGHT-TO-LEFT ISOLATE
+"FSI": "⁨"  # FIRST STRONG ISOLATE
+"PDI": "⁩"  # POP DIRECTIONAL ISOLATE
+"LRO": "‭"  # LEFT-TO-RIGHT OVERRIDE
+"RLO": "‮"  # RIGHT-TO-LEFT OVERRIDE
+"BOM": "﻿"  # ZERO WIDTH NO-BREAK SPACE (Byte Order Mark)
+"CGJ": "͏"  # COMBINING GRAPHEME JOINER
+"WJ": "⁠"  # WORD JOINER
+"a`": "ᴀ"  # LATIN LETTER SMALL CAPITAL A
+"b`": "ʙ"  # LATIN LETTER SMALL CAPITAL B
+"c`": "ᴄ"  # LATIN LETTER SMALL CAPITAL C
+"d`": "ᴅ"  # LATIN LETTER SMALL CAPITAL D
+"e`": "ᴇ"  # LATIN LETTER SMALL CAPITAL E
+"f`": "ꜰ"  # LATIN LETTER SMALL CAPITAL F
+"g`": "ɢ"  # LATIN LETTER SMALL CAPITAL G
+"h`": "ʜ"  # LATIN LETTER SMALL CAPITAL H
+"i`": "ɪ"  # LATIN LETTER SMALL CAPITAL I
+"j`": "ᴊ"  # LATIN LETTER SMALL CAPITAL J
+"k`": "ᴋ"  # LATIN LETTER SMALL CAPITAL K
+"l`": "ʟ"  # LATIN LETTER SMALL CAPITAL L
+"m`": "ᴍ"  # LATIN LETTER SMALL CAPITAL M
+"n`": "ɴ"  # LATIN LETTER SMALL CAPITAL N
+"o`": "ᴏ"  # LATIN LETTER SMALL CAPITAL O
+"p`": "ᴘ"  # LATIN LETTER SMALL CAPITAL P
+"q`": "ꞯ"  # LATIN LETTER SMALL CAPITAL Q
+"r`": "ʀ"  # LATIN LETTER SMALL CAPITAL R
+"s`": "ꜱ"  # LATIN LETTER SMALL CAPITAL S
+"t`": "ᴛ"  # LATIN LETTER SMALL CAPITAL T
+"u`": "ᴜ"  # LATIN LETTER SMALL CAPITAL U
+"v`": "ᴠ"  # LATIN LETTER SMALL CAPITAL V
+"w`": "ᴡ"  # LATIN LETTER SMALL CAPITAL W
+"y`": "ʏ"  # LATIN LETTER SMALL CAPITAL Y
+"z`": "ᴢ"  # LATIN LETTER SMALL CAPITAL Z
+"sun": "☉"  # SUN (Sunday)
+"moon": "☽"  # FIRST QUARTER MOON (Monday)
+"mercury": "☿"  # MERCURY (Wednesday)
+"jupiter": "♃"  # JUPITER (Thursday)
+"saturn": "♄"  # SATURN (Saturday)
+"uranus": "♅"  # URANUS (or ⛢ U26E2?)
+"neptune": "♆"  # NEPTUNE
+"pluto": "♇"  # PLUTO (ok, it isn't a planet anymore, but we still love it.)
+"ceres": "⚳"  # CERES
+"pallas": "⚴"  # PALLAS
+"juno": "⚵"  # JUNO
+"vesta": "⚶"  # VESTA
+"chiron": "⚷"  # CHIRON
+"lilith": "⚸"  # BLACK MOON LILITH
+"[key]": "⚿"  # SQUARED KEY
+"[AS]": "🂡"  # PLAYING CARD ACE OF SPADES
+"[2S]": "🂢"  # PLAYING CARD TWO OF SPADES
+"[3S]": "🂣"  # PLAYING CARD THREE OF SPADES
+"[4S]": "🂤"  # PLAYING CARD FOUR OF SPADES
+"[5S]": "🂥"  # PLAYING CARD FIVE OF SPADES
+"[6S]": "🂦"  # PLAYING CARD SIX OF SPADES
+"[7S]": "🂧"  # PLAYING CARD SEVEN OF SPADES
+"[8S]": "🂨"  # PLAYING CARD EIGHT OF SPADES
+"[9S]": "🂩"  # PLAYING CARD NINE OF SPADES
+"[TS]": "🂪"  # PLAYING CARD TEN OF SPADES
+"[JS]": "🂫"  # PLAYING CARD JACK OF SPADES
+"[NS]": "🂬"  # PLAYING CARD KNIGHT OF SPADES
+"[QS]": "🂭"  # PLAYING CARD QUEEN OF SPADES
+"[KS]": "🂮"  # PLAYING CARD KING OF SPADES
+"[AH]": "🂱"  # PLAYING CARD ACE OF HEARTS
+"[2H]": "🂲"  # PLAYING CARD TWO OF HEARTS
+"[3H]": "🂳"  # PLAYING CARD THREE OF HEARTS
+"[4H]": "🂴"  # PLAYING CARD FOUR OF HEARTS
+"[5H]": "🂵"  # PLAYING CARD FIVE OF HEARTS
+"[6H]": "🂶"  # PLAYING CARD SIX OF HEARTS
+"[7H]": "🂷"  # PLAYING CARD SEVEN OF HEARTS
+"[8H]": "🂸"  # PLAYING CARD EIGHT OF HEARTS
+"[9H]": "🂹"  # PLAYING CARD NINE OF HEARTS
+"[TH]": "🂺"  # PLAYING CARD TEN OF HEARTS
+"[JH]": "🂻"  # PLAYING CARD JACK OF HEARTS
+"[NH]": "🂼"  # PLAYING CARD KNIGHT OF HEARTS
+"[QH]": "🂽"  # PLAYING CARD QUEEN OF HEARTS
+"[KH]": "🂾"  # PLAYING CARD KING OF HEARTS
+"[AD]": "🃁"  # PLAYING CARD ACE OF DIAMONDS
+"[2D]": "🃂"  # PLAYING CARD TWO OF DIAMONDS
+"[3D]": "🃃"  # PLAYING CARD THREE OF DIAMONDS
+"[4D]": "🃄"  # PLAYING CARD FOUR OF DIAMONDS
+"[5D]": "🃅"  # PLAYING CARD FIVE OF DIAMONDS
+"[6D]": "🃆"  # PLAYING CARD SIX OF DIAMONDS
+"[7D]": "🃇"  # PLAYING CARD SEVEN OF DIAMONDS
+"[8D]": "🃈"  # PLAYING CARD EIGHT OF DIAMONDS
+"[9D]": "🃉"  # PLAYING CARD NINE OF DIAMONDS
+"[TD]": "🃊"  # PLAYING CARD TEN OF DIAMONDS
+"[JD]": "🃋"  # PLAYING CARD JACK OF DIAMONDS
+"[ND]": "🃌"  # PLAYING CARD KNIGHT OF DIAMONDS
+"[QD]": "🃍"  # PLAYING CARD QUEEN OF DIAMONDS
+"[KD]": "🃎"  # PLAYING CARD KING OF DIAMONDS
+"[AC]": "🃑"  # PLAYING CARD ACE OF CLUBS
+"[2C]": "🃒"  # PLAYING CARD TWO OF CLUBS
+"[3C]": "🃓"  # PLAYING CARD THREE OF CLUBS
+"[4C]": "🃔"  # PLAYING CARD FOUR OF CLUBS
+"[5C]": "🃕"  # PLAYING CARD FIVE OF CLUBS
+"[6C]": "🃖"  # PLAYING CARD SIX OF CLUBS
+"[7C]": "🃗"  # PLAYING CARD SEVEN OF CLUBS
+"[8C]": "🃘"  # PLAYING CARD EIGHT OF CLUBS
+"[9C]": "🃙"  # PLAYING CARD NINE OF CLUBS
+"[TC]": "🃚"  # PLAYING CARD TEN OF CLUBS
+"[JC]": "🃛"  # PLAYING CARD JACK OF CLUBS
+"[NC]": "🃜"  # PLAYING CARD KNIGHT OF CLUBS
+"[QC]": "🃝"  # PLAYING CARD QUEEN OF CLUBS
+"[KC]": "🃞"  # PLAYING CARD KING OF CLUBS
+"[CB]": "🂠"  # PLAYING CARD BACK
+"[BJ]": "🃏"  # PLAYING CARD BLACK JOKER
+"[WJ]": "🃟"  # PLAYING CARD WHITE JOKER
+"|WK": "♔"  # WHITE CHESS KING
+"|WQ": "♕"  # WHITE CHESS QUEEN
+"|WR": "♖"  # WHITE CHESS ROOK
+"|WB": "♗"  # WHITE CHESS BISHOP
+"|WN": "♘"  # WHITE CHESS KNIGHT
+"|WP": "♙"  # WHITE CHESS PAWN
+"|BK": "♚"  # BLACK CHESS KING
+"|BQ": "♛"  # BLACK CHESS QUEEN
+"|BR": "♜"  # BLACK CHESS ROOK
+"|BB": "♝"  # BLACK CHESS BISHOP
+"|BN": "♞"  # BLACK CHESS KNIGHT
+"|BP": "♟"  # BLACK CHESS PAWN
+"|WDM": "⛀"  # WHITE DRAUGHTS MAN
+"|WDK": "⛁"  # WHITE DRAUGHTS KING
+"|BDM": "⛂"  # BLACK DRAUGHTS MAN
+"|BDK": "⛃"  # BLACK DRAUGHTS KING
+"|WS": "☖"  # WHITE SHOGI PIECE
+"|BS": "☗"  # BLACK SHOGI PIECE
+"|<WS": "⛉"  # TURNED WHITE SHOGI PIECE
+"|<BS": "⛊"  # TURNED BLACK SHOGI PIECE
+"degree": "°"  # DEGREE SIGN
+"degC": "℃"  # DEGREE CELSIUS
+"degc": "℃"  # DEGREE CELSIUS
+"degF": "℉"  # DEGREE FAHRENHEIT
+"degf": "℉"  # DEGREE FAHRENHEIT
+"aries": "♈"  # ARIES
+"taurus": "♉"  # TAURUS
+"gemini": "♊"  # GEMINI
+"cancer": "♋"  # CANCER
+"leo": "♌"  # LEO
+"virgo": "♍"  # VIRGO
+"libra": "♎"  # LIBRA
+"scorp": "♏"  # SCORPIUS
+"sagit": "♐"  # SAGITTARIUS
+"capric": "♑"  # CAPRICORN
+"aquar": "♒"  # AQUARIUS
+"pisces": "♓"  # PISCES
+"ophiuc": "⛎"  # OPHIUCHUS
+"idea": "💡"  # ELECTRIC LIGHT BULB
+"anger": "💢"  # ANGER SYMBOL
+"bomb": "💣"  # BOMB
+"zzz": "💤"  # SLEEPING SYMBOL
+"pow": "💥"  # COLLISION SYMBOL
+"sweat": "💦"  # SPLASHING SWEAT SYMBOL
+"drop": "💧"  # DROPLET
+"zip": "💨"  # DASH SYMBOL
+"poo": "💩"  # PILE OF POO
+"dizzy": "💫"  # DIZZY SYMBOL
+"$bag": "💰"  # MONEY BAG
+"cake": "🍰"  # SHORTCAKE
+"lie": "🎂"  # BIRTHDAY CAKE
+"bday": "🎂"  # BIRTHDAY CAKE
+"AOK": "👌"  # OK HAND SIGN
+"thmup": "👍"  # THUMBS UP SIGN
+"thmdn": "👎"  # THUMBS DOWN SIGN
+"kiss": "💋"  # KISS MARK
+"DNE": "⛔"  # NO ENTRY
+"(1:00)": "🕐"  # CLOCK FACE ONE OCLOCK
+"(2:00)": "🕑"  # CLOCK FACE TWO OCLOCK
+"(3:00)": "🕒"  # CLOCK FACE THREE OCLOCK
+"(4:00)": "🕓"  # CLOCK FACE FOUR OCLOCK
+"(5:00)": "🕔"  # CLOCK FACE FIVE OCLOCK
+"(6:00)": "🕕"  # CLOCK FACE SIX OCLOCK
+"(7:00)": "🕖"  # CLOCK FACE SEVEN OCLOCK
+"(8:00)": "🕗"  # CLOCK FACE EIGHT OCLOCK
+"(9:00)": "🕘"  # CLOCK FACE NINE OCLOCK
+"(10:00)": "🕙"  # CLOCK FACE TEN OCLOCK
+"(11:00)": "🕚"  # CLOCK FACE ELEVEN OCLOCK
+"(12:00)": "🕛"  # CLOCK FACE TWELVE OCLOCK
+"(1:30)": "🕜"  # CLOCK FACE ONE-THIRTY
+"(2:30)": "🕝"  # CLOCK FACE TWO-THIRTY
+"(3:30)": "🕞"  # CLOCK FACE THREE-THIRTY
+"(4:30)": "🕟"  # CLOCK FACE FOUR-THIRTY
+"(5:30)": "🕠"  # CLOCK FACE FIVE-THIRTY
+"(6:30)": "🕡"  # CLOCK FACE SIX-THIRTY
+"(7:30)": "🕢"  # CLOCK FACE SEVEN-THIRTY
+"(8:30)": "🕣"  # CLOCK FACE EIGHT-THIRTY
+"(9:30)": "🕤"  # CLOCK FACE NINE-THIRTY
+"(10:30)": "🕥"  # CLOCK FACE TEN-THIRTY
+"(11:30)": "🕦"  # CLOCK FACE ELEVEN-THIRTY
+"(12:30)": "🕧"  # CLOCK FACE TWELVE-THIRTY
+"B|": "₿"  # BITCOIN SIGN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,10 @@ version = "1.0.1"
 description = "Key generator for macos keybinding system"
 authors = ["Granitosaurus <wraptile@pm.me>"]
 license = "GPL-3.0-or-later"
-packages = [{"include" = "gencompose.py"}]
+packages = [
+    {"include" = "gencompose.py"},
+    {"include" = "convcompose.py"}
+]
 readme = "README.md"
 homepage = "https://github.com/Granitosaurus/macos-compose"
 repository = "https://github.com/Granitosaurus/macos-compose"
@@ -25,6 +28,7 @@ pyyaml = "^5.3.1"
 
 [tool.poetry.scripts]
 gen-compose = "gencompose:main"
+gen-compose-convert = "convcompose:main"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen-compose"
-version = "1.0.1"
+version = "1.1.0"
 description = "Key generator for macos keybinding system"
 authors = ["Granitosaurus <wraptile@pm.me>"]
 license = "GPL-3.0-or-later"
@@ -25,6 +25,7 @@ click = "^7.1.2"
 pyyaml = "^5.3.1"
 
 [tool.poetry.dev-dependencies]
+pytest = "^6.1.0"
 
 [tool.poetry.scripts]
 gen-compose = "gencompose:main"

--- a/tests/test.compose
+++ b/tests/test.compose
@@ -1,0 +1,5 @@
+# some leading comments
+# that should be ignored
+<Multi_key> <period> <period>		: "…"	U2026		# HORIZONTAL ELLIPSIS
+
+# spaces and line breaking comments should be ignored too

--- a/tests/test_convcompose.py
+++ b/tests/test_convcompose.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+from convcompose import main
+
+
+def test_xcompose_convert():
+    runner = CliRunner()
+    file = Path(__file__).parent / 'test.compose'
+    result = runner.invoke(main, args=['xcompose', str(file)])
+    assert result.exit_code == 0
+    assert result.output == '"..": "…"\n'
+    result = runner.invoke(main, args=['xcompose', str(file), '--keep-comments'])
+    assert result.exit_code == 0
+    assert result.output == '"..": "…"  # HORIZONTAL ELLIPSIS\n'


### PR DESCRIPTION
Linux's xcompose mappings support `.xcompose` to `.yaml` conversion:

```
$ gen-compose-conver xcompose --help
Usage: gen-compose-convert xcompose [OPTIONS] [FILES]...
  Convert xcompose file, that follows format like: <Multi_key> <parenleft>
  <period> <1> <parenright>: "⑴"
Options:
  -c, --keep-comments  keep inline comments
  --help               Show this message and exit.
```

For example:

```
$ cat mappings/example.compose
<Multi_key> <B> <bar> : "₿" U20BF  # BITCOIN SIGN
$ gen-compose-convert xcompose mappings/example.compose --keep-comments > example.yaml
$ cat example.yaml
"B|": "₿"  # BITCOIN SIGN
```